### PR TITLE
Add option to control safe mode

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -61,10 +61,11 @@ function enableDisableRender() {
 }
 
 function refreshOptions() {
-    var customAttributes = localStorage.getItem("CUSTOM_ATTRIBUTES");
-    chrome.storage.local.set({'CUSTOM_ATTRIBUTES':customAttributes});
-    var theme = localStorage.getItem("THEME");
-    chrome.storage.local.set({'THEME':theme});
+    chrome.storage.local.set({
+        'CUSTOM_ATTRIBUTES': localStorage['CUSTOM_ATTRIBUTES'],
+        'SAFE_MODE': localStorage['SAFE_MODE'],
+        'THEME': localStorage['THEME']
+    });
 }
 
 chrome.browserAction.onClicked.addListener(enableDisableRender);

--- a/js/options.js
+++ b/js/options.js
@@ -3,6 +3,9 @@ function save_options() {
     var inputCustomAttributes = document.getElementById("inputCustomAttributes");
     localStorage["CUSTOM_ATTRIBUTES"] = inputCustomAttributes.value;
 
+    var selectSafeMode = document.getElementById("selectSafeMode");
+    localStorage["SAFE_MODE"] = selectSafeMode.value;
+
     var selectTheme = document.getElementById("selectTheme");
     localStorage["THEME"] = selectTheme.value;
 
@@ -20,11 +23,14 @@ function restore_options() {
         var inputCustomAttributes = document.getElementById("inputCustomAttributes");
         inputCustomAttributes.value = customAttributes;
     }
-    var theme = localStorage["THEME"];
-    if (theme) {
-        var selectTheme = document.getElementById("selectTheme");
-        selectTheme.value = theme;
-    }
+
+    var safeMode = localStorage["SAFE_MODE"] || 'secure';
+    var selectSafeMode = document.getElementById("selectSafeMode");
+    selectSafeMode.value = safeMode;
+
+    var theme = localStorage["THEME"] || 'asciidoctor';
+    var selectTheme = document.getElementById("selectTheme");
+    selectTheme.value = theme;
 }
 
 document.addEventListener('DOMContentLoaded', restore_options);

--- a/options.html
+++ b/options.html
@@ -15,11 +15,23 @@
 
             <div class="col-lg-10">
                 <input type="text" class="form-control" id="inputCustomAttributes">
-                <span class="help-block">String of space-separated key/value attribute pairs.</span>
+                <span class="help-block">A string of space-separated key/value attribute pairs (e.g., source-highlighter=highlightjs). <a href="http://asciidoctor.org/docs/user-manual/#attributes">Learn more</a> about attributes.</span>
             </div>
         </div>
         <div class="form-group">
-            <label for="selectTheme" class="col-lg-2 control-label">Theme</label>
+            <label for="selectSafeMode" class="col-lg-2 control-label">Safe mode</label>
+            <div class="col-lg-10">
+                <select class="form-control" id="selectSafeMode">
+                  <option value="unsafe">unsafe</option>
+                  <option value="safe">safe</option>
+                  <option value="server">server</option>
+                  <option value="secure">secure</option>
+                </select>
+                <span class="help-block">Controls features related to security. <a href="http://asciidoctor.org/docs/user-manual/#running-asciidoctor-securely">Learn more</a> about these values.</span>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="selectTheme" class="col-lg-2 control-label">Theme / Stylesheet</label>
 
             <div class="col-lg-10">
                 <select class="form-control" id="selectTheme">
@@ -37,6 +49,7 @@
 		    <option>rocket-panda</option>
 		    <option>rubygems</option>
 		</select>
+                <span class="help-block">The CSS styles to apply to the rendered HTML.</span>
             </div>
         </div>
         <div class="form-group">


### PR DESCRIPTION
Add option to control safe mode in preparation for include directives being supported.
- add option to options page to set safe mode
- temporarily disable includes using max-include-depth=0 attribute
- set base_dir to dirname of window.location.href
- add help to all options and link to user manual
- minor cleanups
