### PR TITLE
Override Content-Security-Policy header for Asciidoc files

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -61,3 +61,19 @@ function refreshOptions() {
 
 chrome.browserAction.onClicked.addListener(enableDisableRender);
 enableDisableRender();
+
+var headerReceivedUrls = chrome.runtime.getManifest().content_scripts[0].matches;
+chrome.webRequest.onHeadersReceived.addListener(function(details) {
+      for (var i = 0; i < details.responseHeaders.length; ++i) {
+        if (details.responseHeaders[i].name.toLowerCase() === 'content-security-policy') {
+          details.responseHeaders[i].value = "default-src *; script-src 'self'; style-src 'self' 'unsafe-inline';";
+          break;
+        }
+      }
+      return {responseHeaders: details.responseHeaders};
+  }, {
+    urls : headerReceivedUrls
+  },
+
+  ["blocking", "responseHeaders"]
+);

--- a/manifest.json
+++ b/manifest.json
@@ -67,7 +67,9 @@
         "storage",
         "tabs",
         "<all_urls>",
-        "contextMenus"
+        "contextMenus",
+        "webRequest",
+        "webRequestBlocking"
     ],
     "browser_action":{
         "default_title":"Asciidoctor.js Preview"


### PR DESCRIPTION
If the server responds with a CSP, then Chrome Extensions will use the
CSP in the header as apposed to the CSP specified in the manifest. This
means for sites like github, we were unable to use inline styles.

To resolve this issue this commit will set the CSP response header on
Asciidoc files to the same value that the Atom editor is using.

Fixes #37
