### PR TITLE
🐛 Show the 'allow access to local file' alert only on Chrome and Opera

### DIFF
--- a/app/html/options.html
+++ b/app/html/options.html
@@ -37,13 +37,13 @@
 <div class="container">
   <h1>Options</h1>
 
-  <div id="enablingLocalFileAlert" class="alert alert-info">
+  <div id="enablingLocalFileAlert" class="alert alert-info" style="display: none;">
     <button type="button" class="close">
       <span aria-hidden="true">&times;</span>
       <span class="sr-only">Close</span>
     </button>
     <div class="content">
-      <strong><i class="fa fa-info-circle"></i> Heads up!</strong> If your are using Chrome, in order to use this extension on local files (i.e. files on this computer), you must check the option <code>Allow access to file URLs</code> on the <a id="openExtensionsPageLink" href="#">chrome://extensions</a> page
+      <strong><i class="fa fa-info-circle"></i> Heads up!</strong> If your are using Chrome or Opera, in order to use this extension on local files (i.e. files on this computer), you must check the option <code>Allow access to file URLs</code> on the <a id="openExtensionsPageLink" href="#">chrome://extensions</a> page
     </div>
   </div>
   <form class="form-horizontal" role="form">

--- a/app/js/options.js
+++ b/app/js/options.js
@@ -17,11 +17,29 @@ const openExtensionsPageLink = $('#openExtensionsPageLink');
 
 let saveAction;
 
-openExtensionsPageLink.click(openExtensionsPage);
 $(document).bind('ready', restoreOptions);
 
-function openExtensionsPage () {
-  webExtension.tabs.create({'url': 'browser://extensions/?id=flahcdpicipahcghebiillhbjilehfhc'});
+function showEnablingLocalFileAlert () {
+  openExtensionsPageLink.click(function () {
+    webExtension.tabs.create({'url': 'chrome://extensions/?id=' + webExtension.runtime.id});
+  });
+  initAlert(enablingLocalFileAlert);
+  enablingLocalFileAlert.show();
+}
+
+function initEnablingLocalFileAlert () {
+  // This API is currently only implemented in Firefox and Firefox Mobile.
+  // Reference: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/getBrowserInfo
+  if (typeof webExtension.runtime.getBrowserInfo === 'function') {
+    webExtension.runtime.getBrowserInfo().then(function (info) {
+      if (info.name.includes('Chrome') || info.name.includes('Opera')) {
+        showEnablingLocalFileAlert();
+      }
+    });
+  } else {
+    // Assume that we are running Chrome or Opera (even if it can be Edge)
+    showEnablingLocalFileAlert();
+  }
 }
 
 function optionsChanged () {
@@ -86,8 +104,7 @@ function initAlert (element) {
 initAlert(saveAlert);
 initAlert(addCustomThemeAlert);
 initAlert(addCustomJavaScriptAlert);
-initAlert(enablingLocalFileAlert);
-enablingLocalFileAlert.show();
+initEnablingLocalFileAlert();
 
 inputCustomTheme.change(function () {
   resetAlert(addCustomThemeAlert);


### PR DESCRIPTION
Use runtime.id to retrieve extension's id.