### PR TITLE
Force an AJAX query when using Firefox

### DIFF
--- a/app/js/loader.js
+++ b/app/js/loader.js
@@ -73,10 +73,31 @@ asciidoctor.browser.loader = (webExtension, document, location, XMLHttpRequest, 
     document.body.appendChild(preElement);
   };
 
+  const getBrowserInfo = () => {
+    const userAgent = navigator.userAgent;
+    let name;
+    if (userAgent.indexOf('Chrome') > -1) {
+      name = 'Chrome';
+    } else if (userAgent.indexOf('Safari') > -1) {
+      name = 'Safari';
+    } else if (userAgent.indexOf('Opera') > -1) {
+      name = 'Opera';
+    } else if (userAgent.indexOf('Firefox') > -1) {
+      name = 'Firefox';
+    } else {
+      name = 'Edge';
+    }
+    return {name: name};
+  };
+
   const fetchContent = async () => {
     let textContent;
     // Check if the content is available before using an AJAX query
-    if (document.body.getElementsByTagName('pre').length === 1 && document.body.childNodes.length === 1) {
+    // Note: Firefox is not (yet) using UTF-8 to read BOMless file: https://bugzilla.mozilla.org/show_bug.cgi?id=1071816
+    // As a result the text content could contain invalid characters, to avoid that we force an AJAX query with charset=utf-8
+    // This issue should be fixed in Firefox 60, if this is the case we could potentially remove this condition
+    const browserInfo = await getBrowserInfo();
+    if (browserInfo.name !== 'Firefox' && document.body.getElementsByTagName('pre').length === 1 && document.body.childNodes.length === 1) {
       textContent = document.body.getElementsByTagName('pre')[0].innerText;
     } else {
       const request = await executeRequest(location.href);


### PR DESCRIPTION
BOMless local file are not encoded in UTF-8 by default.

Related issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1071816