### PR TITLE
Document the fact that Firefox needs explicit user input to execute an extension on file:// URLs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,6 +47,7 @@ On Firefox, pages viewed directly from GitHub may not render properly. This is r
 
 In addition, Firefox does not allow access to `file://` URLs unless explicit user input.
 It means that you must type or copy the `file://` URL into your browser address bar and then press "Enter".
+There's an open issue in the https://bugzilla.mozilla.org/show_bug.cgi?id=1266960[Firefox bug tracker] to fix this limitation.
 ====
 
 == Installation

--- a/README.adoc
+++ b/README.adoc
@@ -41,8 +41,13 @@ image:https://dev.opera.com/extensions/branding-guidelines/addons_206x58_en@2x.p
  2. Open local or remote .ad, .adoc, .asc, .asciidoc files in Firefox
  3. Enjoy!
 
-WARNING: On Firefox, pages viewed directly from GitHub may not render properly. This is result of a https://bugzilla.mozilla.org/show_bug.cgi?id=1267027[Firefox bug] carrying over the restrictive content security policies (CSP) that GitHub sends to content inserted by the WebExtension.
-Please note that this issue can also occured on other websites with restictive CSP.
+[WARNING]
+====
+On Firefox, pages viewed directly from GitHub may not render properly. This is result of a https://bugzilla.mozilla.org/show_bug.cgi?id=1267027[Firefox bug] carrying over the restrictive content security policies (CSP) that GitHub sends to content inserted by the WebExtension.
+
+In addition, Firefox does not allow access to `file://` URLs unless explicit user input.
+It means that you must type or copy the `file://` URL into your browser address bar and then press "Enter".
+====
 
 == Installation
 

--- a/README.adoc
+++ b/README.adoc
@@ -43,11 +43,13 @@ image:https://dev.opera.com/extensions/branding-guidelines/addons_206x58_en@2x.p
 
 [WARNING]
 ====
-On Firefox, pages viewed directly from GitHub may not render properly. This is result of a https://bugzilla.mozilla.org/show_bug.cgi?id=1267027[Firefox bug] carrying over the restrictive content security policies (CSP) that GitHub sends to content inserted by the WebExtension.
+On Firefox, pages viewed directly from GitHub may not render properly.
+This is result of a https://bugzilla.mozilla.org/show_bug.cgi?id=1267027[Firefox bug] carrying over the Content Security Policies (CSP).
+The restrictive CSP sent by GitHub are applied to the content inserted by the WebExtension.
 
-In addition, Firefox does not allow access to `file://` URLs unless explicit user input.
-It means that you must type or copy the `file://` URL into your browser address bar and then press "Enter".
-There's an open issue in the https://bugzilla.mozilla.org/show_bug.cgi?id=1266960[Firefox bug tracker] to fix this limitation.
+In addition, Firefox does not trigger the extension when navigating to a `file://` from a link.
+Instead, you have to enter the `file://` URL directly into the address bar of the browser.
+If you do navigate to a `file://` URL from a link, simply highlight the address bar and press "Enter" to force the extension to load. There's an open issue in the https://bugzilla.mozilla.org/show_bug.cgi?id=1266960[Firefox bug tracker] to fix this limitation.
 ====
 
 == Installation

--- a/README.adoc
+++ b/README.adoc
@@ -47,7 +47,7 @@ On Firefox, pages viewed directly from GitHub may not render properly.
 This is result of a https://bugzilla.mozilla.org/show_bug.cgi?id=1267027[Firefox bug] carrying over the Content Security Policies (CSP).
 The restrictive CSP sent by GitHub are applied to the content inserted by the WebExtension.
 
-In addition, Firefox does not trigger the extension when navigating to a `file://` from a link.
+In addition, the extension does not automatically trigger in Firefox when navigating to a `file://` from a link.
 Instead, you have to enter the `file://` URL directly into the address bar of the browser.
 If you do navigate to a `file://` URL from a link, simply highlight the address bar and press "Enter" to force the extension to load. There's an open issue in the https://bugzilla.mozilla.org/show_bug.cgi?id=1266960[Firefox bug tracker] to fix this limitation.
 ====


### PR DESCRIPTION
Ref #256 

@aivarannamaa @jasontibbitts @mojavelinux is it clear enough ?