### PR TITLE
resolves #277 the default safe mode is now safe (was secure)

### DIFF
--- a/app/js/module/settings.js
+++ b/app/js/module/settings.js
@@ -4,7 +4,7 @@ asciidoctor.browser.settings = ((webExtension, Constants) => {
   class RenderingSettings {
     constructor (customAttributes, safeMode, customScript) {
       this.customAttributes = customAttributes;
-      this.safeMode = safeMode || 'secure';
+      this.safeMode = safeMode || 'safe';
       this.customScript = customScript;
     }
   }

--- a/app/js/options.js
+++ b/app/js/options.js
@@ -69,7 +69,7 @@ const webExtension = typeof browser === 'undefined' ? chrome : browser;
    */
   const restoreOptions = () => {
     inputCustomAttributes.value = localStorage['CUSTOM_ATTRIBUTES'] || '';
-    selectSafeMode.value = localStorage['SAFE_MODE'] || 'secure';
+    selectSafeMode.value = localStorage['SAFE_MODE'] || 'safe';
     selectLocalPollFrequency.value = localStorage['LOCAL_POLL_FREQUENCY'] || '2';
     selectRemotePollFrequency.value = localStorage['REMOTE_POLL_FREQUENCY'] || '2';
     inputAllowTxtExtension.checked = localStorage['ALLOW_TXT_EXTENSION'] === 'true';

--- a/spec/asciidocify-rendering-settings-spec.js
+++ b/spec/asciidocify-rendering-settings-spec.js
@@ -17,12 +17,12 @@ describe('Retrieve the rendering settings', () => {
       });
   });
 
-  it('should return \'secure\' if the safe mode is undefined', (done) => {
+  it('should return \'safe\' if the safe mode is undefined', (done) => {
     helper.configureParameters();
 
     Settings.getRenderingSettings()
       .then((renderingSettings) => {
-        expect(renderingSettings.safeMode).toBe('secure');
+        expect(renderingSettings.safeMode).toBe('safe');
         done();
       });
   });


### PR DESCRIPTION
When safe mode is secure, the include directive and source highlighting are disabled (among other things).
To provide a better out-of-the-box experience, the default safe mode is now safe.