### PR TITLE
resolves #310 fix Kroki on Firefox

### DIFF
--- a/app/js/renderer.js
+++ b/app/js/renderer.js
@@ -337,6 +337,8 @@ window.MathJax = {
     if (attributesQueryParameters.length > 0) {
       Array.prototype.push.apply(attributes, attributesQueryParameters)
     }
+    // Forcibly remove the "kroki-fetch-diagram" attribute because this feature is not supported in a browser environment.
+    attributes.push('kroki-fetch-diagram!')
     const registry = processor.Extensions.create()
     if (settings.krokiEnabled) {
       AsciidoctorKroki.register(registry, {

--- a/app/js/vendor/kroki.js
+++ b/app/js/vendor/kroki.js
@@ -15977,12 +15977,9 @@ function diagramBlock (context) {
       try {
         return processKroki(this, parent, attrs, diagramType, diagramText, context)
       } catch (e) {
-        if (e.name === 'UnsupportedFormatError' || e.name === 'InvalidConfigurationError') {
-          console.warn(`Skipping ${diagramType} block. ${e.message}`)
-          attrs.role = role ? `${role} kroki-error` : 'kroki-error'
-          return this.createBlock(parent, attrs['cloaked-context'], diagramText, attrs)
-        }
-        throw e
+        console.warn(`Skipping ${diagramType} block. ${e.message}`)
+        attrs.role = role ? `${role} kroki-error` : 'kroki-error'
+        return this.createBlock(parent, attrs['cloaked-context'], diagramText, attrs)
       }
     })
   }

--- a/app/js/vendor/kroki.js
+++ b/app/js/vendor/kroki.js
@@ -2671,7 +2671,7 @@ function validateParams (params) {
   return params
 }
 
-},{"http":49,"url":56}],9:[function(require,module,exports){
+},{"http":48,"url":55}],9:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = (nBytes * 8) - mLen - 1
@@ -10040,7 +10040,8 @@ var substr = 'ab'.substr(-1) === 'b'
 (function (process){
 'use strict';
 
-if (!process.version ||
+if (typeof process === 'undefined' ||
+    !process.version ||
     process.version.indexOf('v0.') === 0 ||
     process.version.indexOf('v1.') === 0 && process.version.indexOf('v1.8.') !== 0) {
   module.exports = { nextTick: nextTick };
@@ -12188,7 +12189,7 @@ function indexOf(xs, x) {
   return -1;
 }
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./_stream_duplex":37,"./internal/streams/BufferList":42,"./internal/streams/destroy":43,"./internal/streams/stream":44,"_process":32,"core-util-is":6,"events":7,"inherits":10,"isarray":12,"process-nextick-args":31,"safe-buffer":48,"string_decoder/":45,"util":2}],40:[function(require,module,exports){
+},{"./_stream_duplex":37,"./internal/streams/BufferList":42,"./internal/streams/destroy":43,"./internal/streams/stream":44,"_process":32,"core-util-is":6,"events":7,"inherits":10,"isarray":12,"process-nextick-args":31,"safe-buffer":45,"string_decoder/":46,"util":2}],40:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -13093,7 +13094,7 @@ Writable.prototype._destroy = function (err, cb) {
   cb(err);
 };
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("timers").setImmediate)
-},{"./_stream_duplex":37,"./internal/streams/destroy":43,"./internal/streams/stream":44,"_process":32,"core-util-is":6,"inherits":10,"process-nextick-args":31,"safe-buffer":48,"timers":53,"util-deprecate":58}],42:[function(require,module,exports){
+},{"./_stream_duplex":37,"./internal/streams/destroy":43,"./internal/streams/stream":44,"_process":32,"core-util-is":6,"inherits":10,"process-nextick-args":31,"safe-buffer":45,"timers":52,"util-deprecate":57}],42:[function(require,module,exports){
 'use strict';
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -13173,7 +13174,7 @@ if (util && util.inspect && util.inspect.custom) {
     return this.constructor.name + ' ' + obj;
   };
 }
-},{"safe-buffer":48,"util":2}],43:[function(require,module,exports){
+},{"safe-buffer":45,"util":2}],43:[function(require,module,exports){
 'use strict';
 
 /*<replacement>*/
@@ -13252,6 +13253,70 @@ module.exports = {
 module.exports = require('events').EventEmitter;
 
 },{"events":7}],45:[function(require,module,exports){
+/* eslint-disable node/no-deprecated-api */
+var buffer = require('buffer')
+var Buffer = buffer.Buffer
+
+// alternative to using Object.keys for old browsers
+function copyProps (src, dst) {
+  for (var key in src) {
+    dst[key] = src[key]
+  }
+}
+if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
+  module.exports = buffer
+} else {
+  // Copy properties from require('buffer')
+  copyProps(buffer, exports)
+  exports.Buffer = SafeBuffer
+}
+
+function SafeBuffer (arg, encodingOrOffset, length) {
+  return Buffer(arg, encodingOrOffset, length)
+}
+
+// Copy static methods from Buffer
+copyProps(Buffer, SafeBuffer)
+
+SafeBuffer.from = function (arg, encodingOrOffset, length) {
+  if (typeof arg === 'number') {
+    throw new TypeError('Argument must not be a number')
+  }
+  return Buffer(arg, encodingOrOffset, length)
+}
+
+SafeBuffer.alloc = function (size, fill, encoding) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
+  }
+  var buf = Buffer(size)
+  if (fill !== undefined) {
+    if (typeof encoding === 'string') {
+      buf.fill(fill, encoding)
+    } else {
+      buf.fill(fill)
+    }
+  } else {
+    buf.fill(0)
+  }
+  return buf
+}
+
+SafeBuffer.allocUnsafe = function (size) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
+  }
+  return Buffer(size)
+}
+
+SafeBuffer.allocUnsafeSlow = function (size) {
+  if (typeof size !== 'number') {
+    throw new TypeError('Argument must be a number')
+  }
+  return buffer.SlowBuffer(size)
+}
+
+},{"buffer":4}],46:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -13548,7 +13613,7 @@ function simpleWrite(buf) {
 function simpleEnd(buf) {
   return buf && buf.length ? this.write(buf) : '';
 }
-},{"safe-buffer":48}],46:[function(require,module,exports){
+},{"safe-buffer":45}],47:[function(require,module,exports){
 exports = module.exports = require('./lib/_stream_readable.js');
 exports.Stream = exports;
 exports.Readable = exports;
@@ -13557,1000 +13622,7 @@ exports.Duplex = require('./lib/_stream_duplex.js');
 exports.Transform = require('./lib/_stream_transform.js');
 exports.PassThrough = require('./lib/_stream_passthrough.js');
 
-},{"./lib/_stream_duplex.js":37,"./lib/_stream_passthrough.js":38,"./lib/_stream_readable.js":39,"./lib/_stream_transform.js":40,"./lib/_stream_writable.js":41}],47:[function(require,module,exports){
-(function webpackUniversalModuleDefinition(root, factory) {
-	if(typeof exports === 'object' && typeof module === 'object')
-		module.exports = factory();
-	else if(typeof define === 'function' && define.amd)
-		define([], factory);
-	else if(typeof exports === 'object')
-		exports["Rusha"] = factory();
-	else
-		root["Rusha"] = factory();
-})(typeof self !== 'undefined' ? self : this, function() {
-return /******/ (function(modules) { // webpackBootstrap
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
-/******/
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
-/******/
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId]) {
-/******/ 			return installedModules[moduleId].exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			i: moduleId,
-/******/ 			l: false,
-/******/ 			exports: {}
-/******/ 		};
-/******/
-/******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
-/******/
-/******/ 		// Flag the module as loaded
-/******/ 		module.l = true;
-/******/
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
-/******/
-/******/
-/******/ 	// expose the modules object (__webpack_modules__)
-/******/ 	__webpack_require__.m = modules;
-/******/
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
-/******/
-/******/ 	// define getter function for harmony exports
-/******/ 	__webpack_require__.d = function(exports, name, getter) {
-/******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
-/******/ 		}
-/******/ 	};
-/******/
-/******/ 	// getDefaultExport function for compatibility with non-harmony modules
-/******/ 	__webpack_require__.n = function(module) {
-/******/ 		var getter = module && module.__esModule ?
-/******/ 			function getDefault() { return module['default']; } :
-/******/ 			function getModuleExports() { return module; };
-/******/ 		__webpack_require__.d(getter, 'a', getter);
-/******/ 		return getter;
-/******/ 	};
-/******/
-/******/ 	// Object.prototype.hasOwnProperty.call
-/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
-/******/
-/******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "";
-/******/
-/******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 3);
-/******/ })
-/************************************************************************/
-/******/ ([
-/* 0 */
-/***/ (function(module, exports, __webpack_require__) {
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-/* eslint-env commonjs, browser */
-
-var RushaCore = __webpack_require__(5);
-
-var _require = __webpack_require__(1),
-    toHex = _require.toHex,
-    ceilHeapSize = _require.ceilHeapSize;
-
-var conv = __webpack_require__(6);
-
-// Calculate the length of buffer that the sha1 routine uses
-// including the padding.
-var padlen = function (len) {
-  for (len += 9; len % 64 > 0; len += 1) {}
-  return len;
-};
-
-var padZeroes = function (bin, len) {
-  var h8 = new Uint8Array(bin.buffer);
-  var om = len % 4,
-      align = len - om;
-  switch (om) {
-    case 0:
-      h8[align + 3] = 0;
-    case 1:
-      h8[align + 2] = 0;
-    case 2:
-      h8[align + 1] = 0;
-    case 3:
-      h8[align + 0] = 0;
-  }
-  for (var i = (len >> 2) + 1; i < bin.length; i++) {
-    bin[i] = 0;
-  }
-};
-
-var padData = function (bin, chunkLen, msgLen) {
-  bin[chunkLen >> 2] |= 0x80 << 24 - (chunkLen % 4 << 3);
-  // To support msgLen >= 2 GiB, use a float division when computing the
-  // high 32-bits of the big-endian message length in bits.
-  bin[((chunkLen >> 2) + 2 & ~0x0f) + 14] = msgLen / (1 << 29) | 0;
-  bin[((chunkLen >> 2) + 2 & ~0x0f) + 15] = msgLen << 3;
-};
-
-var getRawDigest = function (heap, padMaxChunkLen) {
-  var io = new Int32Array(heap, padMaxChunkLen + 320, 5);
-  var out = new Int32Array(5);
-  var arr = new DataView(out.buffer);
-  arr.setInt32(0, io[0], false);
-  arr.setInt32(4, io[1], false);
-  arr.setInt32(8, io[2], false);
-  arr.setInt32(12, io[3], false);
-  arr.setInt32(16, io[4], false);
-  return out;
-};
-
-var Rusha = function () {
-  function Rusha(chunkSize) {
-    _classCallCheck(this, Rusha);
-
-    chunkSize = chunkSize || 64 * 1024;
-    if (chunkSize % 64 > 0) {
-      throw new Error('Chunk size must be a multiple of 128 bit');
-    }
-    this._offset = 0;
-    this._maxChunkLen = chunkSize;
-    this._padMaxChunkLen = padlen(chunkSize);
-    // The size of the heap is the sum of:
-    // 1. The padded input message size
-    // 2. The extended space the algorithm needs (320 byte)
-    // 3. The 160 bit state the algoritm uses
-    this._heap = new ArrayBuffer(ceilHeapSize(this._padMaxChunkLen + 320 + 20));
-    this._h32 = new Int32Array(this._heap);
-    this._h8 = new Int8Array(this._heap);
-    this._core = new RushaCore({ Int32Array: Int32Array }, {}, this._heap);
-  }
-
-  Rusha.prototype._initState = function _initState(heap, padMsgLen) {
-    this._offset = 0;
-    var io = new Int32Array(heap, padMsgLen + 320, 5);
-    io[0] = 1732584193;
-    io[1] = -271733879;
-    io[2] = -1732584194;
-    io[3] = 271733878;
-    io[4] = -1009589776;
-  };
-
-  Rusha.prototype._padChunk = function _padChunk(chunkLen, msgLen) {
-    var padChunkLen = padlen(chunkLen);
-    var view = new Int32Array(this._heap, 0, padChunkLen >> 2);
-    padZeroes(view, chunkLen);
-    padData(view, chunkLen, msgLen);
-    return padChunkLen;
-  };
-
-  Rusha.prototype._write = function _write(data, chunkOffset, chunkLen, off) {
-    conv(data, this._h8, this._h32, chunkOffset, chunkLen, off || 0);
-  };
-
-  Rusha.prototype._coreCall = function _coreCall(data, chunkOffset, chunkLen, msgLen, finalize) {
-    var padChunkLen = chunkLen;
-    this._write(data, chunkOffset, chunkLen);
-    if (finalize) {
-      padChunkLen = this._padChunk(chunkLen, msgLen);
-    }
-    this._core.hash(padChunkLen, this._padMaxChunkLen);
-  };
-
-  Rusha.prototype.rawDigest = function rawDigest(str) {
-    var msgLen = str.byteLength || str.length || str.size || 0;
-    this._initState(this._heap, this._padMaxChunkLen);
-    var chunkOffset = 0,
-        chunkLen = this._maxChunkLen;
-    for (chunkOffset = 0; msgLen > chunkOffset + chunkLen; chunkOffset += chunkLen) {
-      this._coreCall(str, chunkOffset, chunkLen, msgLen, false);
-    }
-    this._coreCall(str, chunkOffset, msgLen - chunkOffset, msgLen, true);
-    return getRawDigest(this._heap, this._padMaxChunkLen);
-  };
-
-  Rusha.prototype.digest = function digest(str) {
-    return toHex(this.rawDigest(str).buffer);
-  };
-
-  Rusha.prototype.digestFromString = function digestFromString(str) {
-    return this.digest(str);
-  };
-
-  Rusha.prototype.digestFromBuffer = function digestFromBuffer(str) {
-    return this.digest(str);
-  };
-
-  Rusha.prototype.digestFromArrayBuffer = function digestFromArrayBuffer(str) {
-    return this.digest(str);
-  };
-
-  Rusha.prototype.resetState = function resetState() {
-    this._initState(this._heap, this._padMaxChunkLen);
-    return this;
-  };
-
-  Rusha.prototype.append = function append(chunk) {
-    var chunkOffset = 0;
-    var chunkLen = chunk.byteLength || chunk.length || chunk.size || 0;
-    var turnOffset = this._offset % this._maxChunkLen;
-    var inputLen = void 0;
-
-    this._offset += chunkLen;
-    while (chunkOffset < chunkLen) {
-      inputLen = Math.min(chunkLen - chunkOffset, this._maxChunkLen - turnOffset);
-      this._write(chunk, chunkOffset, inputLen, turnOffset);
-      turnOffset += inputLen;
-      chunkOffset += inputLen;
-      if (turnOffset === this._maxChunkLen) {
-        this._core.hash(this._maxChunkLen, this._padMaxChunkLen);
-        turnOffset = 0;
-      }
-    }
-    return this;
-  };
-
-  Rusha.prototype.getState = function getState() {
-    var turnOffset = this._offset % this._maxChunkLen;
-    var heap = void 0;
-    if (!turnOffset) {
-      var io = new Int32Array(this._heap, this._padMaxChunkLen + 320, 5);
-      heap = io.buffer.slice(io.byteOffset, io.byteOffset + io.byteLength);
-    } else {
-      heap = this._heap.slice(0);
-    }
-    return {
-      offset: this._offset,
-      heap: heap
-    };
-  };
-
-  Rusha.prototype.setState = function setState(state) {
-    this._offset = state.offset;
-    if (state.heap.byteLength === 20) {
-      var io = new Int32Array(this._heap, this._padMaxChunkLen + 320, 5);
-      io.set(new Int32Array(state.heap));
-    } else {
-      this._h32.set(new Int32Array(state.heap));
-    }
-    return this;
-  };
-
-  Rusha.prototype.rawEnd = function rawEnd() {
-    var msgLen = this._offset;
-    var chunkLen = msgLen % this._maxChunkLen;
-    var padChunkLen = this._padChunk(chunkLen, msgLen);
-    this._core.hash(padChunkLen, this._padMaxChunkLen);
-    var result = getRawDigest(this._heap, this._padMaxChunkLen);
-    this._initState(this._heap, this._padMaxChunkLen);
-    return result;
-  };
-
-  Rusha.prototype.end = function end() {
-    return toHex(this.rawEnd().buffer);
-  };
-
-  return Rusha;
-}();
-
-module.exports = Rusha;
-module.exports._core = RushaCore;
-
-/***/ }),
-/* 1 */
-/***/ (function(module, exports) {
-
-/* eslint-env commonjs, browser */
-
-//
-// toHex
-//
-
-var precomputedHex = new Array(256);
-for (var i = 0; i < 256; i++) {
-  precomputedHex[i] = (i < 0x10 ? '0' : '') + i.toString(16);
-}
-
-module.exports.toHex = function (arrayBuffer) {
-  var binarray = new Uint8Array(arrayBuffer);
-  var res = new Array(arrayBuffer.byteLength);
-  for (var _i = 0; _i < res.length; _i++) {
-    res[_i] = precomputedHex[binarray[_i]];
-  }
-  return res.join('');
-};
-
-//
-// ceilHeapSize
-//
-
-module.exports.ceilHeapSize = function (v) {
-  // The asm.js spec says:
-  // The heap object's byteLength must be either
-  // 2^n for n in [12, 24) or 2^24 * n for n ≥ 1.
-  // Also, byteLengths smaller than 2^16 are deprecated.
-  var p = 0;
-  // If v is smaller than 2^16, the smallest possible solution
-  // is 2^16.
-  if (v <= 65536) return 65536;
-  // If v < 2^24, we round up to 2^n,
-  // otherwise we round up to 2^24 * n.
-  if (v < 16777216) {
-    for (p = 1; p < v; p = p << 1) {}
-  } else {
-    for (p = 16777216; p < v; p += 16777216) {}
-  }
-  return p;
-};
-
-//
-// isDedicatedWorkerScope
-//
-
-module.exports.isDedicatedWorkerScope = function (self) {
-  var isRunningInWorker = 'WorkerGlobalScope' in self && self instanceof self.WorkerGlobalScope;
-  var isRunningInSharedWorker = 'SharedWorkerGlobalScope' in self && self instanceof self.SharedWorkerGlobalScope;
-  var isRunningInServiceWorker = 'ServiceWorkerGlobalScope' in self && self instanceof self.ServiceWorkerGlobalScope;
-
-  // Detects whether we run inside a dedicated worker or not.
-  //
-  // We can't just check for `DedicatedWorkerGlobalScope`, since IE11
-  // has a bug where it only supports `WorkerGlobalScope`.
-  //
-  // Therefore, we consider us as running inside a dedicated worker
-  // when we are running inside a worker, but not in a shared or service worker.
-  //
-  // When new types of workers are introduced, we will need to adjust this code.
-  return isRunningInWorker && !isRunningInSharedWorker && !isRunningInServiceWorker;
-};
-
-/***/ }),
-/* 2 */
-/***/ (function(module, exports, __webpack_require__) {
-
-/* eslint-env commonjs, worker */
-
-module.exports = function () {
-  var Rusha = __webpack_require__(0);
-
-  var hashData = function (hasher, data, cb) {
-    try {
-      return cb(null, hasher.digest(data));
-    } catch (e) {
-      return cb(e);
-    }
-  };
-
-  var hashFile = function (hasher, readTotal, blockSize, file, cb) {
-    var reader = new self.FileReader();
-    reader.onloadend = function onloadend() {
-      if (reader.error) {
-        return cb(reader.error);
-      }
-      var buffer = reader.result;
-      readTotal += reader.result.byteLength;
-      try {
-        hasher.append(buffer);
-      } catch (e) {
-        cb(e);
-        return;
-      }
-      if (readTotal < file.size) {
-        hashFile(hasher, readTotal, blockSize, file, cb);
-      } else {
-        cb(null, hasher.end());
-      }
-    };
-    reader.readAsArrayBuffer(file.slice(readTotal, readTotal + blockSize));
-  };
-
-  var workerBehaviourEnabled = true;
-
-  self.onmessage = function (event) {
-    if (!workerBehaviourEnabled) {
-      return;
-    }
-
-    var data = event.data.data,
-        file = event.data.file,
-        id = event.data.id;
-    if (typeof id === 'undefined') return;
-    if (!file && !data) return;
-    var blockSize = event.data.blockSize || 4 * 1024 * 1024;
-    var hasher = new Rusha(blockSize);
-    hasher.resetState();
-    var done = function (err, hash) {
-      if (!err) {
-        self.postMessage({ id: id, hash: hash });
-      } else {
-        self.postMessage({ id: id, error: err.name });
-      }
-    };
-    if (data) hashData(hasher, data, done);
-    if (file) hashFile(hasher, 0, blockSize, file, done);
-  };
-
-  return function () {
-    workerBehaviourEnabled = false;
-  };
-};
-
-/***/ }),
-/* 3 */
-/***/ (function(module, exports, __webpack_require__) {
-
-/* eslint-env commonjs, browser */
-
-var work = __webpack_require__(4);
-var Rusha = __webpack_require__(0);
-var createHash = __webpack_require__(7);
-var runWorker = __webpack_require__(2);
-
-var _require = __webpack_require__(1),
-    isDedicatedWorkerScope = _require.isDedicatedWorkerScope;
-
-var isRunningInDedicatedWorker = typeof self !== 'undefined' && isDedicatedWorkerScope(self);
-
-Rusha.disableWorkerBehaviour = isRunningInDedicatedWorker ? runWorker() : function () {};
-
-Rusha.createWorker = function () {
-  var worker = work(/*require.resolve*/(2));
-  var terminate = worker.terminate;
-  worker.terminate = function () {
-    URL.revokeObjectURL(worker.objectURL);
-    terminate.call(worker);
-  };
-  return worker;
-};
-
-Rusha.createHash = createHash;
-
-module.exports = Rusha;
-
-/***/ }),
-/* 4 */
-/***/ (function(module, exports, __webpack_require__) {
-
-function webpackBootstrapFunc (modules) {
-/******/  // The module cache
-/******/  var installedModules = {};
-
-/******/  // The require function
-/******/  function __webpack_require__(moduleId) {
-
-/******/    // Check if module is in cache
-/******/    if(installedModules[moduleId])
-/******/      return installedModules[moduleId].exports;
-
-/******/    // Create a new module (and put it into the cache)
-/******/    var module = installedModules[moduleId] = {
-/******/      i: moduleId,
-/******/      l: false,
-/******/      exports: {}
-/******/    };
-
-/******/    // Execute the module function
-/******/    modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
-
-/******/    // Flag the module as loaded
-/******/    module.l = true;
-
-/******/    // Return the exports of the module
-/******/    return module.exports;
-/******/  }
-
-/******/  // expose the modules object (__webpack_modules__)
-/******/  __webpack_require__.m = modules;
-
-/******/  // expose the module cache
-/******/  __webpack_require__.c = installedModules;
-
-/******/  // identity function for calling harmony imports with the correct context
-/******/  __webpack_require__.i = function(value) { return value; };
-
-/******/  // define getter function for harmony exports
-/******/  __webpack_require__.d = function(exports, name, getter) {
-/******/    if(!__webpack_require__.o(exports, name)) {
-/******/      Object.defineProperty(exports, name, {
-/******/        configurable: false,
-/******/        enumerable: true,
-/******/        get: getter
-/******/      });
-/******/    }
-/******/  };
-
-/******/  // define __esModule on exports
-/******/  __webpack_require__.r = function(exports) {
-/******/    Object.defineProperty(exports, '__esModule', { value: true });
-/******/  };
-
-/******/  // getDefaultExport function for compatibility with non-harmony modules
-/******/  __webpack_require__.n = function(module) {
-/******/    var getter = module && module.__esModule ?
-/******/      function getDefault() { return module['default']; } :
-/******/      function getModuleExports() { return module; };
-/******/    __webpack_require__.d(getter, 'a', getter);
-/******/    return getter;
-/******/  };
-
-/******/  // Object.prototype.hasOwnProperty.call
-/******/  __webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
-
-/******/  // __webpack_public_path__
-/******/  __webpack_require__.p = "/";
-
-/******/  // on error function for async loading
-/******/  __webpack_require__.oe = function(err) { console.error(err); throw err; };
-
-  var f = __webpack_require__(__webpack_require__.s = ENTRY_MODULE)
-  return f.default || f // try to call default if defined to also support babel esmodule exports
-}
-
-var moduleNameReqExp = '[\\.|\\-|\\+|\\w|\/|@]+'
-var dependencyRegExp = '\\((\/\\*.*?\\*\/)?\s?.*?(' + moduleNameReqExp + ').*?\\)' // additional chars when output.pathinfo is true
-
-// http://stackoverflow.com/a/2593661/130442
-function quoteRegExp (str) {
-  return (str + '').replace(/[.?*+^$[\]\\(){}|-]/g, '\\$&')
-}
-
-function getModuleDependencies (sources, module, queueName) {
-  var retval = {}
-  retval[queueName] = []
-
-  var fnString = module.toString()
-  var wrapperSignature = fnString.match(/^function\s?\(\w+,\s*\w+,\s*(\w+)\)/)
-  if (!wrapperSignature) return retval
-  var webpackRequireName = wrapperSignature[1]
-
-  // main bundle deps
-  var re = new RegExp('(\\\\n|\\W)' + quoteRegExp(webpackRequireName) + dependencyRegExp, 'g')
-  var match
-  while ((match = re.exec(fnString))) {
-    if (match[3] === 'dll-reference') continue
-    retval[queueName].push(match[3])
-  }
-
-  // dll deps
-  re = new RegExp('\\(' + quoteRegExp(webpackRequireName) + '\\("(dll-reference\\s(' + moduleNameReqExp + '))"\\)\\)' + dependencyRegExp, 'g')
-  while ((match = re.exec(fnString))) {
-    if (!sources[match[2]]) {
-      retval[queueName].push(match[1])
-      sources[match[2]] = __webpack_require__(match[1]).m
-    }
-    retval[match[2]] = retval[match[2]] || []
-    retval[match[2]].push(match[4])
-  }
-
-  return retval
-}
-
-function hasValuesInQueues (queues) {
-  var keys = Object.keys(queues)
-  return keys.reduce(function (hasValues, key) {
-    return hasValues || queues[key].length > 0
-  }, false)
-}
-
-function getRequiredModules (sources, moduleId) {
-  var modulesQueue = {
-    main: [moduleId]
-  }
-  var requiredModules = {
-    main: []
-  }
-  var seenModules = {
-    main: {}
-  }
-
-  while (hasValuesInQueues(modulesQueue)) {
-    var queues = Object.keys(modulesQueue)
-    for (var i = 0; i < queues.length; i++) {
-      var queueName = queues[i]
-      var queue = modulesQueue[queueName]
-      var moduleToCheck = queue.pop()
-      seenModules[queueName] = seenModules[queueName] || {}
-      if (seenModules[queueName][moduleToCheck] || !sources[queueName][moduleToCheck]) continue
-      seenModules[queueName][moduleToCheck] = true
-      requiredModules[queueName] = requiredModules[queueName] || []
-      requiredModules[queueName].push(moduleToCheck)
-      var newModules = getModuleDependencies(sources, sources[queueName][moduleToCheck], queueName)
-      var newModulesKeys = Object.keys(newModules)
-      for (var j = 0; j < newModulesKeys.length; j++) {
-        modulesQueue[newModulesKeys[j]] = modulesQueue[newModulesKeys[j]] || []
-        modulesQueue[newModulesKeys[j]] = modulesQueue[newModulesKeys[j]].concat(newModules[newModulesKeys[j]])
-      }
-    }
-  }
-
-  return requiredModules
-}
-
-module.exports = function (moduleId, options) {
-  options = options || {}
-  var sources = {
-    main: __webpack_require__.m
-  }
-
-  var requiredModules = options.all ? { main: Object.keys(sources) } : getRequiredModules(sources, moduleId)
-
-  var src = ''
-
-  Object.keys(requiredModules).filter(function (m) { return m !== 'main' }).forEach(function (module) {
-    var entryModule = 0
-    while (requiredModules[module][entryModule]) {
-      entryModule++
-    }
-    requiredModules[module].push(entryModule)
-    sources[module][entryModule] = '(function(module, exports, __webpack_require__) { module.exports = __webpack_require__; })'
-    src = src + 'var ' + module + ' = (' + webpackBootstrapFunc.toString().replace('ENTRY_MODULE', JSON.stringify(entryModule)) + ')({' + requiredModules[module].map(function (id) { return '' + JSON.stringify(id) + ': ' + sources[module][id].toString() }).join(',') + '});\n'
-  })
-
-  src = src + '(' + webpackBootstrapFunc.toString().replace('ENTRY_MODULE', JSON.stringify(moduleId)) + ')({' + requiredModules.main.map(function (id) { return '' + JSON.stringify(id) + ': ' + sources.main[id].toString() }).join(',') + '})(self);'
-
-  var blob = new window.Blob([src], { type: 'text/javascript' })
-  if (options.bare) { return blob }
-
-  var URL = window.URL || window.webkitURL || window.mozURL || window.msURL
-
-  var workerUrl = URL.createObjectURL(blob)
-  var worker = new window.Worker(workerUrl)
-  worker.objectURL = workerUrl
-
-  return worker
-}
-
-
-/***/ }),
-/* 5 */
-/***/ (function(module, exports) {
-
-// The low-level RushCore module provides the heart of Rusha,
-// a high-speed sha1 implementation working on an Int32Array heap.
-// At first glance, the implementation seems complicated, however
-// with the SHA1 spec at hand, it is obvious this almost a textbook
-// implementation that has a few functions hand-inlined and a few loops
-// hand-unrolled.
-module.exports = function RushaCore(stdlib$846, foreign$847, heap$848) {
-    'use asm';
-    var H$849 = new stdlib$846.Int32Array(heap$848);
-    function hash$850(k$851, x$852) {
-        // k in bytes
-        k$851 = k$851 | 0;
-        x$852 = x$852 | 0;
-        var i$853 = 0, j$854 = 0, y0$855 = 0, z0$856 = 0, y1$857 = 0, z1$858 = 0, y2$859 = 0, z2$860 = 0, y3$861 = 0, z3$862 = 0, y4$863 = 0, z4$864 = 0, t0$865 = 0, t1$866 = 0;
-        y0$855 = H$849[x$852 + 320 >> 2] | 0;
-        y1$857 = H$849[x$852 + 324 >> 2] | 0;
-        y2$859 = H$849[x$852 + 328 >> 2] | 0;
-        y3$861 = H$849[x$852 + 332 >> 2] | 0;
-        y4$863 = H$849[x$852 + 336 >> 2] | 0;
-        for (i$853 = 0; (i$853 | 0) < (k$851 | 0); i$853 = i$853 + 64 | 0) {
-            z0$856 = y0$855;
-            z1$858 = y1$857;
-            z2$860 = y2$859;
-            z3$862 = y3$861;
-            z4$864 = y4$863;
-            for (j$854 = 0; (j$854 | 0) < 64; j$854 = j$854 + 4 | 0) {
-                t1$866 = H$849[i$853 + j$854 >> 2] | 0;
-                t0$865 = ((y0$855 << 5 | y0$855 >>> 27) + (y1$857 & y2$859 | ~y1$857 & y3$861) | 0) + ((t1$866 + y4$863 | 0) + 1518500249 | 0) | 0;
-                y4$863 = y3$861;
-                y3$861 = y2$859;
-                y2$859 = y1$857 << 30 | y1$857 >>> 2;
-                y1$857 = y0$855;
-                y0$855 = t0$865;
-                H$849[k$851 + j$854 >> 2] = t1$866;
-            }
-            for (j$854 = k$851 + 64 | 0; (j$854 | 0) < (k$851 + 80 | 0); j$854 = j$854 + 4 | 0) {
-                t1$866 = (H$849[j$854 - 12 >> 2] ^ H$849[j$854 - 32 >> 2] ^ H$849[j$854 - 56 >> 2] ^ H$849[j$854 - 64 >> 2]) << 1 | (H$849[j$854 - 12 >> 2] ^ H$849[j$854 - 32 >> 2] ^ H$849[j$854 - 56 >> 2] ^ H$849[j$854 - 64 >> 2]) >>> 31;
-                t0$865 = ((y0$855 << 5 | y0$855 >>> 27) + (y1$857 & y2$859 | ~y1$857 & y3$861) | 0) + ((t1$866 + y4$863 | 0) + 1518500249 | 0) | 0;
-                y4$863 = y3$861;
-                y3$861 = y2$859;
-                y2$859 = y1$857 << 30 | y1$857 >>> 2;
-                y1$857 = y0$855;
-                y0$855 = t0$865;
-                H$849[j$854 >> 2] = t1$866;
-            }
-            for (j$854 = k$851 + 80 | 0; (j$854 | 0) < (k$851 + 160 | 0); j$854 = j$854 + 4 | 0) {
-                t1$866 = (H$849[j$854 - 12 >> 2] ^ H$849[j$854 - 32 >> 2] ^ H$849[j$854 - 56 >> 2] ^ H$849[j$854 - 64 >> 2]) << 1 | (H$849[j$854 - 12 >> 2] ^ H$849[j$854 - 32 >> 2] ^ H$849[j$854 - 56 >> 2] ^ H$849[j$854 - 64 >> 2]) >>> 31;
-                t0$865 = ((y0$855 << 5 | y0$855 >>> 27) + (y1$857 ^ y2$859 ^ y3$861) | 0) + ((t1$866 + y4$863 | 0) + 1859775393 | 0) | 0;
-                y4$863 = y3$861;
-                y3$861 = y2$859;
-                y2$859 = y1$857 << 30 | y1$857 >>> 2;
-                y1$857 = y0$855;
-                y0$855 = t0$865;
-                H$849[j$854 >> 2] = t1$866;
-            }
-            for (j$854 = k$851 + 160 | 0; (j$854 | 0) < (k$851 + 240 | 0); j$854 = j$854 + 4 | 0) {
-                t1$866 = (H$849[j$854 - 12 >> 2] ^ H$849[j$854 - 32 >> 2] ^ H$849[j$854 - 56 >> 2] ^ H$849[j$854 - 64 >> 2]) << 1 | (H$849[j$854 - 12 >> 2] ^ H$849[j$854 - 32 >> 2] ^ H$849[j$854 - 56 >> 2] ^ H$849[j$854 - 64 >> 2]) >>> 31;
-                t0$865 = ((y0$855 << 5 | y0$855 >>> 27) + (y1$857 & y2$859 | y1$857 & y3$861 | y2$859 & y3$861) | 0) + ((t1$866 + y4$863 | 0) - 1894007588 | 0) | 0;
-                y4$863 = y3$861;
-                y3$861 = y2$859;
-                y2$859 = y1$857 << 30 | y1$857 >>> 2;
-                y1$857 = y0$855;
-                y0$855 = t0$865;
-                H$849[j$854 >> 2] = t1$866;
-            }
-            for (j$854 = k$851 + 240 | 0; (j$854 | 0) < (k$851 + 320 | 0); j$854 = j$854 + 4 | 0) {
-                t1$866 = (H$849[j$854 - 12 >> 2] ^ H$849[j$854 - 32 >> 2] ^ H$849[j$854 - 56 >> 2] ^ H$849[j$854 - 64 >> 2]) << 1 | (H$849[j$854 - 12 >> 2] ^ H$849[j$854 - 32 >> 2] ^ H$849[j$854 - 56 >> 2] ^ H$849[j$854 - 64 >> 2]) >>> 31;
-                t0$865 = ((y0$855 << 5 | y0$855 >>> 27) + (y1$857 ^ y2$859 ^ y3$861) | 0) + ((t1$866 + y4$863 | 0) - 899497514 | 0) | 0;
-                y4$863 = y3$861;
-                y3$861 = y2$859;
-                y2$859 = y1$857 << 30 | y1$857 >>> 2;
-                y1$857 = y0$855;
-                y0$855 = t0$865;
-                H$849[j$854 >> 2] = t1$866;
-            }
-            y0$855 = y0$855 + z0$856 | 0;
-            y1$857 = y1$857 + z1$858 | 0;
-            y2$859 = y2$859 + z2$860 | 0;
-            y3$861 = y3$861 + z3$862 | 0;
-            y4$863 = y4$863 + z4$864 | 0;
-        }
-        H$849[x$852 + 320 >> 2] = y0$855;
-        H$849[x$852 + 324 >> 2] = y1$857;
-        H$849[x$852 + 328 >> 2] = y2$859;
-        H$849[x$852 + 332 >> 2] = y3$861;
-        H$849[x$852 + 336 >> 2] = y4$863;
-    }
-    return { hash: hash$850 };
-};
-
-/***/ }),
-/* 6 */
-/***/ (function(module, exports) {
-
-var _this = this;
-
-/* eslint-env commonjs, browser */
-
-var reader = void 0;
-if (typeof self !== 'undefined' && typeof self.FileReaderSync !== 'undefined') {
-  reader = new self.FileReaderSync();
-}
-
-// Convert a binary string and write it to the heap.
-// A binary string is expected to only contain char codes < 256.
-var convStr = function (str, H8, H32, start, len, off) {
-  var i = void 0,
-      om = off % 4,
-      lm = (len + om) % 4,
-      j = len - lm;
-  switch (om) {
-    case 0:
-      H8[off] = str.charCodeAt(start + 3);
-    case 1:
-      H8[off + 1 - (om << 1) | 0] = str.charCodeAt(start + 2);
-    case 2:
-      H8[off + 2 - (om << 1) | 0] = str.charCodeAt(start + 1);
-    case 3:
-      H8[off + 3 - (om << 1) | 0] = str.charCodeAt(start);
-  }
-  if (len < lm + (4 - om)) {
-    return;
-  }
-  for (i = 4 - om; i < j; i = i + 4 | 0) {
-    H32[off + i >> 2] = str.charCodeAt(start + i) << 24 | str.charCodeAt(start + i + 1) << 16 | str.charCodeAt(start + i + 2) << 8 | str.charCodeAt(start + i + 3);
-  }
-  switch (lm) {
-    case 3:
-      H8[off + j + 1 | 0] = str.charCodeAt(start + j + 2);
-    case 2:
-      H8[off + j + 2 | 0] = str.charCodeAt(start + j + 1);
-    case 1:
-      H8[off + j + 3 | 0] = str.charCodeAt(start + j);
-  }
-};
-
-// Convert a buffer or array and write it to the heap.
-// The buffer or array is expected to only contain elements < 256.
-var convBuf = function (buf, H8, H32, start, len, off) {
-  var i = void 0,
-      om = off % 4,
-      lm = (len + om) % 4,
-      j = len - lm;
-  switch (om) {
-    case 0:
-      H8[off] = buf[start + 3];
-    case 1:
-      H8[off + 1 - (om << 1) | 0] = buf[start + 2];
-    case 2:
-      H8[off + 2 - (om << 1) | 0] = buf[start + 1];
-    case 3:
-      H8[off + 3 - (om << 1) | 0] = buf[start];
-  }
-  if (len < lm + (4 - om)) {
-    return;
-  }
-  for (i = 4 - om; i < j; i = i + 4 | 0) {
-    H32[off + i >> 2 | 0] = buf[start + i] << 24 | buf[start + i + 1] << 16 | buf[start + i + 2] << 8 | buf[start + i + 3];
-  }
-  switch (lm) {
-    case 3:
-      H8[off + j + 1 | 0] = buf[start + j + 2];
-    case 2:
-      H8[off + j + 2 | 0] = buf[start + j + 1];
-    case 1:
-      H8[off + j + 3 | 0] = buf[start + j];
-  }
-};
-
-var convBlob = function (blob, H8, H32, start, len, off) {
-  var i = void 0,
-      om = off % 4,
-      lm = (len + om) % 4,
-      j = len - lm;
-  var buf = new Uint8Array(reader.readAsArrayBuffer(blob.slice(start, start + len)));
-  switch (om) {
-    case 0:
-      H8[off] = buf[3];
-    case 1:
-      H8[off + 1 - (om << 1) | 0] = buf[2];
-    case 2:
-      H8[off + 2 - (om << 1) | 0] = buf[1];
-    case 3:
-      H8[off + 3 - (om << 1) | 0] = buf[0];
-  }
-  if (len < lm + (4 - om)) {
-    return;
-  }
-  for (i = 4 - om; i < j; i = i + 4 | 0) {
-    H32[off + i >> 2 | 0] = buf[i] << 24 | buf[i + 1] << 16 | buf[i + 2] << 8 | buf[i + 3];
-  }
-  switch (lm) {
-    case 3:
-      H8[off + j + 1 | 0] = buf[j + 2];
-    case 2:
-      H8[off + j + 2 | 0] = buf[j + 1];
-    case 1:
-      H8[off + j + 3 | 0] = buf[j];
-  }
-};
-
-module.exports = function (data, H8, H32, start, len, off) {
-  if (typeof data === 'string') {
-    return convStr(data, H8, H32, start, len, off);
-  }
-  if (data instanceof Array) {
-    return convBuf(data, H8, H32, start, len, off);
-  }
-  // Safely doing a Buffer check using "this" to avoid Buffer polyfill to be included in the dist
-  if (_this && _this.Buffer && _this.Buffer.isBuffer(data)) {
-    return convBuf(data, H8, H32, start, len, off);
-  }
-  if (data instanceof ArrayBuffer) {
-    return convBuf(new Uint8Array(data), H8, H32, start, len, off);
-  }
-  if (data.buffer instanceof ArrayBuffer) {
-    return convBuf(new Uint8Array(data.buffer, data.byteOffset, data.byteLength), H8, H32, start, len, off);
-  }
-  if (data instanceof Blob) {
-    return convBlob(data, H8, H32, start, len, off);
-  }
-  throw new Error('Unsupported data type.');
-};
-
-/***/ }),
-/* 7 */
-/***/ (function(module, exports, __webpack_require__) {
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-/* eslint-env commonjs, browser */
-
-var Rusha = __webpack_require__(0);
-
-var _require = __webpack_require__(1),
-    toHex = _require.toHex;
-
-var Hash = function () {
-  function Hash() {
-    _classCallCheck(this, Hash);
-
-    this._rusha = new Rusha();
-    this._rusha.resetState();
-  }
-
-  Hash.prototype.update = function update(data) {
-    this._rusha.append(data);
-    return this;
-  };
-
-  Hash.prototype.digest = function digest(encoding) {
-    var digest = this._rusha.rawEnd().buffer;
-    if (!encoding) {
-      return digest;
-    }
-    if (encoding === 'hex') {
-      return toHex(digest);
-    }
-    throw new Error('unsupported digest encoding');
-  };
-
-  return Hash;
-}();
-
-module.exports = function () {
-  return new Hash();
-};
-
-/***/ })
-/******/ ]);
-});
-},{}],48:[function(require,module,exports){
-/* eslint-disable node/no-deprecated-api */
-var buffer = require('buffer')
-var Buffer = buffer.Buffer
-
-// alternative to using Object.keys for old browsers
-function copyProps (src, dst) {
-  for (var key in src) {
-    dst[key] = src[key]
-  }
-}
-if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
-  module.exports = buffer
-} else {
-  // Copy properties from require('buffer')
-  copyProps(buffer, exports)
-  exports.Buffer = SafeBuffer
-}
-
-function SafeBuffer (arg, encodingOrOffset, length) {
-  return Buffer(arg, encodingOrOffset, length)
-}
-
-// Copy static methods from Buffer
-copyProps(Buffer, SafeBuffer)
-
-SafeBuffer.from = function (arg, encodingOrOffset, length) {
-  if (typeof arg === 'number') {
-    throw new TypeError('Argument must not be a number')
-  }
-  return Buffer(arg, encodingOrOffset, length)
-}
-
-SafeBuffer.alloc = function (size, fill, encoding) {
-  if (typeof size !== 'number') {
-    throw new TypeError('Argument must be a number')
-  }
-  var buf = Buffer(size)
-  if (fill !== undefined) {
-    if (typeof encoding === 'string') {
-      buf.fill(fill, encoding)
-    } else {
-      buf.fill(fill)
-    }
-  } else {
-    buf.fill(0)
-  }
-  return buf
-}
-
-SafeBuffer.allocUnsafe = function (size) {
-  if (typeof size !== 'number') {
-    throw new TypeError('Argument must be a number')
-  }
-  return Buffer(size)
-}
-
-SafeBuffer.allocUnsafeSlow = function (size) {
-  if (typeof size !== 'number') {
-    throw new TypeError('Argument must be a number')
-  }
-  return buffer.SlowBuffer(size)
-}
-
-},{"buffer":4}],49:[function(require,module,exports){
+},{"./lib/_stream_duplex.js":37,"./lib/_stream_passthrough.js":38,"./lib/_stream_readable.js":39,"./lib/_stream_transform.js":40,"./lib/_stream_writable.js":41}],48:[function(require,module,exports){
 (function (global){
 var ClientRequest = require('./lib/request')
 var response = require('./lib/response')
@@ -14638,7 +13710,7 @@ http.METHODS = [
 	'UNSUBSCRIBE'
 ]
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./lib/request":51,"./lib/response":52,"builtin-status-codes":5,"url":56,"xtend":59}],50:[function(require,module,exports){
+},{"./lib/request":50,"./lib/response":51,"builtin-status-codes":5,"url":55,"xtend":58}],49:[function(require,module,exports){
 (function (global){
 exports.fetch = isFunction(global.fetch) && isFunction(global.ReadableStream)
 
@@ -14715,7 +13787,7 @@ function isFunction (value) {
 xhr = null // Help gc
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],51:[function(require,module,exports){
+},{}],50:[function(require,module,exports){
 (function (process,global,Buffer){
 var capability = require('./capability')
 var inherits = require('inherits')
@@ -15046,7 +14118,7 @@ var unsafeHeaders = [
 ]
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"./capability":50,"./response":52,"_process":32,"buffer":4,"inherits":10,"readable-stream":46,"to-arraybuffer":54}],52:[function(require,module,exports){
+},{"./capability":49,"./response":51,"_process":32,"buffer":4,"inherits":10,"readable-stream":47,"to-arraybuffer":53}],51:[function(require,module,exports){
 (function (process,global,Buffer){
 var capability = require('./capability')
 var inherits = require('inherits')
@@ -15274,7 +14346,7 @@ IncomingMessage.prototype._onXHRProgress = function () {
 }
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("buffer").Buffer)
-},{"./capability":50,"_process":32,"buffer":4,"inherits":10,"readable-stream":46}],53:[function(require,module,exports){
+},{"./capability":49,"_process":32,"buffer":4,"inherits":10,"readable-stream":47}],52:[function(require,module,exports){
 (function (setImmediate,clearImmediate){
 var nextTick = require('process/browser.js').nextTick;
 var apply = Function.prototype.apply;
@@ -15353,7 +14425,7 @@ exports.clearImmediate = typeof clearImmediate === "function" ? clearImmediate :
   delete immediateIds[id];
 };
 }).call(this,require("timers").setImmediate,require("timers").clearImmediate)
-},{"process/browser.js":32,"timers":53}],54:[function(require,module,exports){
+},{"process/browser.js":32,"timers":52}],53:[function(require,module,exports){
 var Buffer = require('buffer').Buffer
 
 module.exports = function (buf) {
@@ -15382,7 +14454,7 @@ module.exports = function (buf) {
 	}
 }
 
-},{"buffer":4}],55:[function(require,module,exports){
+},{"buffer":4}],54:[function(require,module,exports){
 (function (process,Buffer,__dirname){
 /**
  * Wrapper for built-in http.js to emulate the browser XMLHttpRequest object.
@@ -15984,7 +15056,7 @@ exports.XMLHttpRequest = function () {
 }
 
 }).call(this,require('_process'),require("buffer").Buffer,"/node_modules/unxhr/lib")
-},{"_process":32,"buffer":4,"child_process":2,"fs":2,"http":49,"https":8,"path":30,"url":56}],56:[function(require,module,exports){
+},{"_process":32,"buffer":4,"child_process":2,"fs":2,"http":48,"https":8,"path":30,"url":55}],55:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -16718,7 +15790,7 @@ Url.prototype.parseHost = function() {
   if (host) this.hostname = host;
 };
 
-},{"./util":57,"punycode":33,"querystring":36}],57:[function(require,module,exports){
+},{"./util":56,"punycode":33,"querystring":36}],56:[function(require,module,exports){
 'use strict';
 
 module.exports = {
@@ -16736,7 +15808,7 @@ module.exports = {
   }
 };
 
-},{}],58:[function(require,module,exports){
+},{}],57:[function(require,module,exports){
 (function (global){
 
 /**
@@ -16807,7 +15879,7 @@ function config (name) {
 }
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],59:[function(require,module,exports){
+},{}],58:[function(require,module,exports){
 module.exports = extend
 
 var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -16828,7 +15900,7 @@ function extend() {
     return target
 }
 
-},{}],60:[function(require,module,exports){
+},{}],59:[function(require,module,exports){
 (function (Buffer){
 const pako = require('pako')
 
@@ -16928,16 +16000,13 @@ function diagramBlockMacro (name, context) {
       const role = attrs.role
       const diagramType = name
       target = parent.$apply_subs(target, ['attributes'])
-      let diagramText = vfs.read(target)
       try {
+        const diagramText = vfs.read(target)
         return processKroki(this, parent, attrs, diagramType, diagramText, context)
       } catch (e) {
-        if (e.name === 'UnsupportedFormatError' || e.name === 'InvalidConfigurationError') {
-          console.warn(`Skipping ${diagramType} block macro. ${e.message}`)
-          attrs.role = role ? `${role} kroki-error` : 'kroki-error'
-          return this.createBlock(parent, 'paragraph', `${e.message} - ${diagramType}::${target}[]`, attrs)
-        }
-        throw e
+        console.warn(`Skipping ${diagramType} block macro. ${e.message}`)
+        attrs.role = role ? `${role} kroki-error` : 'kroki-error'
+        return this.createBlock(parent, 'paragraph', `${e.message} - ${diagramType}::${target}[]`, attrs)
       }
     })
   }
@@ -16962,65 +16031,7 @@ module.exports.register = function register (registry, context = {}) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./fetch":61,"./node-fs":62,"buffer":4,"pako":14}],61:[function(require,module,exports){
-(function (Buffer){
-const rusha = require('rusha')
-const path = require('path')
-
-module.exports.save = function (diagramUrl, doc, target, format, vfs) {
-  const imagesOutputDir = doc.getAttribute('imagesoutdir')
-  const outDir = doc.getAttribute('outdir')
-  const toDir = doc.getAttribute('to_dir')
-  const baseDir = doc.getAttribute('base_dir') || ''
-  const imagesDir = doc.getAttribute('imagesdir') || ''
-  let dirPath
-  if (imagesOutputDir) {
-    dirPath = imagesOutputDir
-  } else if (outDir) {
-    dirPath = path.join(outDir, imagesDir)
-  } else if (toDir) {
-    dirPath = path.join(toDir, imagesDir)
-  } else {
-    dirPath = path.join(baseDir, imagesDir)
-  }
-  const diagramName = `${rusha.createHash().update(diagramUrl).digest('hex')}.${format}`
-  let exists
-  if (typeof vfs === 'undefined' || typeof vfs.exists !== 'function') {
-    exists = require('./node-fs').exists
-  } else {
-    exists = vfs.exists
-  }
-  let read
-  if (typeof vfs === 'undefined' || typeof vfs.read !== 'function') {
-    read = require('./node-fs').read
-  } else {
-    read = vfs.read
-  }
-  const filePath = path.format({ dir: dirPath, base: diagramName })
-  let contents
-  if (exists(filePath)) {
-    // file already exists on the file system
-    contents = read(filePath, 'binary')
-  } else {
-    contents = read(diagramUrl, 'binary')
-  }
-  let add
-  if (typeof vfs === 'undefined' || typeof vfs.add !== 'function') {
-    add = require('./node-fs').add
-  } else {
-    add = vfs.add
-  }
-  add({
-    relative: dirPath,
-    basename: diagramName,
-    mediaType: format === 'svg' ? 'image/svg+xml' : 'image/png',
-    contents: Buffer.from(contents, 'binary')
-  })
-  return diagramName
-}
-
-}).call(this,require("buffer").Buffer)
-},{"./node-fs":62,"buffer":4,"path":30,"rusha":47}],62:[function(require,module,exports){
+},{"./fetch":undefined,"./node-fs":60,"buffer":4,"pako":14}],60:[function(require,module,exports){
 const fs = require('fs')
 const path = require('path')
 const mkdirp = require('mkdirp')
@@ -17047,7 +16058,7 @@ module.exports = {
   }
 }
 
-},{"./node-http":63,"fs":3,"mkdirp":13,"path":30}],63:[function(require,module,exports){
+},{"./node-http":61,"fs":3,"mkdirp":13,"path":30}],61:[function(require,module,exports){
 const httpGet = (uri, encoding = 'utf8') => {
   let data = ''
   let status = -1
@@ -17087,5 +16098,5 @@ module.exports = {
   get: httpGet
 }
 
-},{"unxhr":55}]},{},[60])(60)
+},{"unxhr":54}]},{},[59])(59)
 });

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -240,6 +240,7 @@
         "js/vendor/highlight.js/languages/zephir.min.js",
         "js/vendor/asciidoctor.js",
         "js/vendor/md5.js",
+        "js/vendor/kroki.js",
         "js/module/namespace.js",
         "js/module/settings.js",
         "js/module/dom.js",
@@ -248,7 +249,6 @@
         "js/renderer.js",
         "js/asciidocify.js",
         "js/vendor/chartist.min.js",
-        "js/vendor/kroki.js",
         "js/vendor/asciidoctor-chart-block-macro.js",
         "js/vendor/asciidoctor-emoji-inline-macro.js"
       ]

--- a/contrib/samples/diagrams.adoc
+++ b/contrib/samples/diagrams.adoc
@@ -1,4 +1,5 @@
 = Diagrams
+:kroki-fetch-diagram:
 
 == PlantUML diagram
 


### PR DESCRIPTION
- Upgrade to asciidoctor-kroki v0.3.0
  - Catch all exceptions when reading a file because Firefox does not allow to read file from `file://` protocol for security reasons.
  - Remove rusha from the bundle because for whatever reason, it does not work on Firefox :disappointed: 
- Load kroki.js before the renderer.js because order matters on Firefox.

resolves #310