### PR TITLE
Refresh the tab when the extension is disabled

### DIFF
--- a/app/js/background.js
+++ b/app/js/background.js
@@ -56,6 +56,10 @@ const { refreshOptions, enableDisableRender } = ((webExtension) => {
     }
   })
 
+  const disableExtension = tab => {
+    webExtension.tabs.reload(tab.id)
+  }
+
   const notifyTab = (tab, status) => {
     webExtension.tabs.sendMessage(tab.id, { status: status })
   }
@@ -94,7 +98,14 @@ const { refreshOptions, enableDisableRender } = ((webExtension) => {
     }
 
     // Reload the active tab in the current windows that matches
-    findActiveTab((activeTab) => notifyTab(activeTab, enableRender ? 'extension-disabled' : 'extension-enabled'))
+    findActiveTab((activeTab) => {
+      if (enableRender) {
+        // opposite action, the extension was enabled, so we disable!
+        disableExtension(activeTab)
+      } else {
+        notifyTab(activeTab, 'extension-enabled')
+      }
+    })
 
     // Switch the flag
     enableRender = !enableRender

--- a/app/js/loader.js
+++ b/app/js/loader.js
@@ -6,8 +6,6 @@ asciidoctor.browser.loader = (webExtension, document, location, XMLHttpRequest, 
     if (sender.id === webExtension.runtime.id) {
       if (message.status === 'extension-enabled') {
         module.load()
-      } else if (message.status === 'extension-disabled') {
-        unloadExtension()
       }
     }
   })
@@ -50,15 +48,6 @@ asciidoctor.browser.loader = (webExtension, document, location, XMLHttpRequest, 
     request.open('GET', `${url}?_=${new Date().getTime()}`, true)
     request.send(null)
   })
-
-  const unloadExtension = async () => {
-    clearInterval(autoReloadInterval)
-    const request = await executeRequest(location.href)
-    if (isHtmlContentType(request)) {
-      return
-    }
-    displayContentAsPlainText(request.responseText)
-  }
 
   /**
    * Display content as plain text.


### PR DESCRIPTION
As the latest version of Chrome 80+ blocks the `XMLHttpRequest`.

Might help #316 and #315