### PR TITLE
Fix mocha deprecation

### DIFF
--- a/spec/browser/asciidoctor-extension-spec.js
+++ b/spec/browser/asciidoctor-extension-spec.js
@@ -9,7 +9,7 @@
   }
   mocha.setup({
     ui: 'bdd',
-    ignoreLeaks: true,
+    checkLeaks: false,
     reporter: reporter
   })
 


### PR DESCRIPTION
ignoreLeaks()" is DEPRECATED, please use "checkLeaks()" instead