### PR TITLE
🐛 resolves #411 fix MathJax equation numbering

### DIFF
--- a/app/js/converter.js
+++ b/app/js/converter.js
@@ -1,5 +1,6 @@
 /* global md5, asciidoctor, XMLHttpRequest, Asciidoctor, AsciidoctorKroki */
 const processor = Asciidoctor({ runtime: { platform: 'browser' } })
+const eqnumValidValues = ['none', 'all', 'ams']
 
 asciidoctor.browser.converter = (webExtension, Constants, Settings) => {
   const module = {}
@@ -15,6 +16,15 @@ asciidoctor.browser.converter = (webExtension, Constants, Settings) => {
       // Force the source highlighter to Highlight.js (since we only support Highlight.js)
       doc.setAttribute('source-highlighter', 'highlight.js')
     }
+    let eqnumsValue = doc.getAttribute('eqnums', 'none').toLowerCase()
+    if (eqnumsValue.trim().length === 0) {
+      // empty value is an alias for AMS-style equation numbering
+      eqnumsValue = 'ams'
+    }
+    if (!eqnumValidValues.includes(eqnumsValue)) {
+      // invalid values are not allowed, use AMS-style equation numbering
+      eqnumsValue = 'ams'
+    }
     return {
       html: doc.convert(),
       text: source,
@@ -27,7 +37,7 @@ asciidoctor.browser.converter = (webExtension, Constants, Settings) => {
         isStemEnabled: isStemEnabled(doc),
         isFontIcons: doc.getAttribute('icons') === 'font',
         maxWidth: doc.getAttribute('max-width'),
-        eqnumsValue: doc.getAttribute('eqnums', 'none'),
+        eqnumsValue,
         stylesheet: doc.getAttribute('stylesheet')
       }
     }

--- a/spec/browser/asciidoctor-extension-spec.js
+++ b/spec/browser/asciidoctor-extension-spec.js
@@ -508,6 +508,108 @@ By default, the title must be shown.
     })
   })
 
+  describe('STEM', () => {
+    afterEach(() => {
+      helper.reset()
+    })
+
+    beforeEach(() => {
+      const mathjaxConfigElement = document.getElementById('asciidoctor-mathjax-config')
+      if (mathjaxConfigElement) {
+        mathjaxConfigElement.parentNode.removeChild(mathjaxConfigElement)
+      }
+    })
+
+    it('should configure AMS-style equation numbering when eqnums is empty', async () => {
+      const params = []
+      params[Constants.ENABLE_RENDER_KEY] = 'true'
+      params[Constants.CUSTOM_ATTRIBUTES_KEY] = ''
+      params[Constants.SAFE_MODE_KEY] = 'safe'
+      helper.configureParameters(params)
+
+      const source = `= Equation number
+:stem: latexmath
+:eqnums:
+
+stem:[\\sin(x^2)]`
+
+      const response = await Converter.convert(window.location.toString(), source)
+      await Renderer.updateHTML(response)
+      expect(document.getElementById('asciidoctor-mathjax-config').innerText).to.includes('tags: "ams"')
+    })
+
+    it('should disable equation numbering when eqnums is missing', async () => {
+      const params = []
+      params[Constants.ENABLE_RENDER_KEY] = 'true'
+      params[Constants.CUSTOM_ATTRIBUTES_KEY] = ''
+      params[Constants.SAFE_MODE_KEY] = 'safe'
+      helper.configureParameters(params)
+
+      const source = `= Equation number
+:stem: latexmath
+
+stem:[\\sin(x^2)]`
+
+      const response = await Converter.convert(window.location.toString(), source)
+      await Renderer.updateHTML(response)
+      expect(document.getElementById('asciidoctor-mathjax-config').innerText).to.includes('tags: "none"')
+    })
+
+    it('should configure AMS-style equation numbering when eqnums contains an invalid value', async () => {
+      const params = []
+      params[Constants.ENABLE_RENDER_KEY] = 'true'
+      params[Constants.CUSTOM_ATTRIBUTES_KEY] = ''
+      params[Constants.SAFE_MODE_KEY] = 'safe'
+      helper.configureParameters(params)
+
+      const source = `= Equation number
+:stem: latexmath
+:eqnums: invalid
+
+stem:[\\sin(x^2)]`
+
+      const response = await Converter.convert(window.location.toString(), source)
+      await Renderer.updateHTML(response)
+      expect(document.getElementById('asciidoctor-mathjax-config').innerText).to.includes('tags: "ams"')
+    })
+
+    it('should enable equation numbering when eqnums is all', async () => {
+      const params = []
+      params[Constants.ENABLE_RENDER_KEY] = 'true'
+      params[Constants.CUSTOM_ATTRIBUTES_KEY] = ''
+      params[Constants.SAFE_MODE_KEY] = 'safe'
+      helper.configureParameters(params)
+
+      const source = `= Equation number
+:stem: latexmath
+:eqnums: all
+
+stem:[\\sin(x^2)]`
+
+      const response = await Converter.convert(window.location.toString(), source)
+      await Renderer.updateHTML(response)
+      expect(document.getElementById('asciidoctor-mathjax-config').innerText).to.includes('tags: "all"')
+    })
+
+    it('should disable equation numbering when eqnums is none', async () => {
+      const params = []
+      params[Constants.ENABLE_RENDER_KEY] = 'true'
+      params[Constants.CUSTOM_ATTRIBUTES_KEY] = ''
+      params[Constants.SAFE_MODE_KEY] = 'safe'
+      helper.configureParameters(params)
+
+      const source = `= Equation number
+:stem: latexmath
+:eqnums: none
+
+stem:[\\sin(x^2)]`
+
+      const response = await Converter.convert(window.location.toString(), source)
+      await Renderer.updateHTML(response)
+      expect(document.getElementById('asciidoctor-mathjax-config').innerText).to.includes('tags: "none"')
+    })
+  })
+
   mocha.run(function (failures) {
     if (failures > 0) {
       console.error('%d failures', failures)


### PR DESCRIPTION
MathJax 3+ does not allow invalid values for equation numbering.
Possible values are:
- `none`
- `all`
- `ams`

See http://docs.mathjax.org/en/latest/options/input/tex.html#tex-options

When the attribute `eqnums` is not set, equation numbering is disabled (`none`).
When the attribute value of `eqnums` is:
- `all`: equation numbering is enabled on all blocks (`all`)
- `none`: equation numbering is disabled (`none`)
- `ams`: AMS-style equation numbering is enabled (`ams`)
- empty: AMS-style equation numbering is enabled (`ams`)
- any other value: AMS-style equation numbering is enabled (`ams`)

This behavior is backward compatible with MathJax 2.7.

resolves #411

//cc @mojavelinux 