### PR TITLE
resolves #660 use title case for page titles

### DIFF
--- a/docs/modules/ROOT/pages/custom-attributes-option.adoc
+++ b/docs/modules/ROOT/pages/custom-attributes-option.adoc
@@ -1,4 +1,4 @@
-= Option: Custom attributes string
+= Option: Custom Attributes String
 :navtitle: Custom attributes string
 
 The extension option *Custom attributes string* on the extension configuration dialog box, is a space-separated list of attribute settings that the {project-name} applies to all documents when rendering them to HTML.
@@ -38,7 +38,7 @@ See section xref:features.adoc#set-asciidoc-attributes[Set AsciiDoc attributes] 
 
 For more ideas and use cases for setting attributes, see the xref:use-cases.adoc[] page.
 
-== AsciiDoc Attributes
+== AsciiDoc attributes
 
 To learn more about AsciiDoc attributes, visit the
 xref:asciidoc:attributes:document-attributes.adoc[]

--- a/docs/modules/ROOT/pages/diagrams-extension-option.adoc
+++ b/docs/modules/ROOT/pages/diagrams-extension-option.adoc
@@ -1,4 +1,4 @@
-= Option: Diagrams extension
+= Option: Diagrams Extension
 :navtitle: Diagrams extension
 :keywords: kroki,diagrams like code,diagrams
 

--- a/docs/modules/ROOT/pages/diagrams-extension-quickstart.adoc
+++ b/docs/modules/ROOT/pages/diagrams-extension-quickstart.adoc
@@ -1,4 +1,4 @@
-= Diagrams extension quickstart
+= Diagrams Extension Quickstart
 
 In this quick start you'll:
 
@@ -24,7 +24,7 @@ To create the above diagram after installing the {project-name}, do the followin
 .diagram-extension-example.adoc
 [,asciidoc]
 ----
-= Diagrams extension example with Kroki.io
+= Diagrams Extension Example with Kroki.io
 
 The sequence diagram is below:
 

--- a/docs/modules/ROOT/pages/features.adoc
+++ b/docs/modules/ROOT/pages/features.adoc
@@ -112,7 +112,7 @@ You should see the following result:
 Query parameters example
 ====
 
-== Change Themes and Stylesheets
+== Change themes and stylesheets
 
 Change the stylesheet, CSS, or both, that are used to render HTML5 from the AsciiDoc.
 For example, you may prefer a darker or a more compact presentation style.

--- a/docs/modules/ROOT/pages/firefox-known-issues.adoc
+++ b/docs/modules/ROOT/pages/firefox-known-issues.adoc
@@ -1,4 +1,4 @@
-= Known Firefox issues
+= Known Firefox Issues
 
 These are the known Firefox issues.
 

--- a/docs/modules/ROOT/pages/install.adoc
+++ b/docs/modules/ROOT/pages/install.adoc
@@ -2,7 +2,7 @@
 
 You can install the extension from your browser's Web Store or a local copy of the extension.
 
-== Install from Web Store
+== Install from a web store
 
 . Install the Extension on your browser using the image links below.
 +

--- a/docs/modules/ROOT/pages/use-cases.adoc
+++ b/docs/modules/ROOT/pages/use-cases.adoc
@@ -1,10 +1,10 @@
 [#use-cases]
-= Use cases
+= Use Cases
 
 Use cases for typical situations you may encounter.
 
 [#uc-add-toc]
-== Add a TOC
+== Add a table of contents (TOC)
 
 Add a TOC to a document written without one, so that it's easier to navigate and use.
 
@@ -43,7 +43,7 @@ To remove a TOC that's already there use `toc` followed by an exclamation mark (
 
 
 [[uc-simplify-toc]]
-== Simplify the TOC
+== Simplify a table of contents
 
 Reduce the TOC heading levels for a simplified view of the document.
 
@@ -75,7 +75,7 @@ Add the `toclevels` setting depending on your need below:
 
 TIP: To see more detail in the TOC, increase the `toclevels` value.
 
-== Add a simplified TOC
+== Add a simplified table of contents
 
 To combine the use cases of <<uc-add-toc>> and <<uc-simplify-toc>> you can set both `toc` and `toclevels` at the same time:
 
@@ -93,7 +93,7 @@ To combine the use cases of <<uc-add-toc>> and <<uc-simplify-toc>> you can set b
  :toclevels: 1
 
 
-== Minimal effort writing
+== Writing with minimal effort
 
 Create and write an AsciiDoc quickly using the {project-name} to apply your most commonly used settings.
 


### PR DESCRIPTION
Keep the same "Title Case Format for Page Titles" format as the core Asciidoctor documentation.