### PR TITLE
chore(deps): update asciidoctor.js to 4.0.7

### DIFF
--- a/app/js/vendor/asciidoctor.js
+++ b/app/js/vendor/asciidoctor.js
@@ -1,4 +1,4 @@
-var version = "4.0.6";
+var version = "4.0.7";
 const packageJson = {
 	version: version};
 
@@ -5247,11 +5247,16 @@ class PathResolver {
     }
 
     const relative = root ? posixPath.slice(root.length) : posixPath;
-    let segments = relative.split(SLASH).filter((s) => s !== DOT && s !== '');
-    // Re-add non-empty-string DOT segments removal is as above; preserve empty for UNC
-    segments = relative.split(SLASH).filter((s) => s !== DOT);
-    // Remove any empty segments (trailing slash artifacts) except retain intent
-    segments = segments.filter((s) => s !== '');
+    // Mirror Ruby's String#split('/'), which drops only *trailing* empty
+    // strings. A leading empty segment must be kept: it's what reconstructs
+    // the missing slash for URI roots that under-consume it, e.g. root
+    // "file://" + relative "/Users/foo" (from "file:///Users/foo") needs
+    // that leading '' so joinPath() rebuilds "file:///Users/foo" and not
+    // "file://Users/foo".
+    const segments = relative.split(SLASH).filter((s) => s !== DOT);
+    while (segments.length && segments[segments.length - 1] === '') {
+      segments.pop();
+    }
 
     const result = [segments, root];
     cache[path] = result;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@asciidoctor/core": "4.0.6",
+        "@asciidoctor/core": "4.0.7",
         "@biomejs/biome": "^2.5.6",
         "@playwright/test": "^1.62.0",
         "archiver": "8.0.0",
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@asciidoctor/core": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.6.tgz",
-      "integrity": "sha512-woI/pRaDQgVg0wtqiHiWV3eCv2CXN5tRwNajX7eYodMwbIAcRufFq9KvSpjAxgvM3x/Xidp7aHYEh6l3msk3tA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.7.tgz",
+      "integrity": "sha512-uJFZD/Ca2+z8rC9Sq5ih7HkpmzoeJXkXCDEoilNRCnXMw33k2zh5U2RhIGvm+t9JFxDjEs/KtzRdD9ugoG+f9A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@asciidoctor/core": "4.0.6",
+    "@asciidoctor/core": "4.0.7",
     "@biomejs/biome": "^2.5.6",
     "@playwright/test": "^1.62.0",
     "archiver": "8.0.0",


### PR DESCRIPTION
Bump the vendored `asciidoctor.js` (built from `@asciidoctor/core`) from 4.0.6 to 4.0.7, along with `package.json` and `package-lock.json`.
