### PR TITLE
feat: render author, revision info, and favicon

### DIFF
--- a/app/js/module/converter.js
+++ b/app/js/module/converter.js
@@ -43,11 +43,41 @@ function isStemEnabled(doc) {
   return doc.isAttribute('stem')
 }
 
+/**
+ * Get the document authors, if any.
+ * @param doc
+ * @returns {Array<{name: string, email: string|null}>}
+ */
+function getAuthors(doc) {
+  return doc.getAuthors().map((author) => ({
+    name: author.getName(),
+    email: author.getEmail(),
+  }))
+}
+
+/**
+ * Get the document revision info (number, date, remark), if any is defined.
+ * @param doc
+ * @returns {{number: string|null, date: string|null, remark: string|null}|undefined}
+ */
+function getRevisionInfo(doc) {
+  const revisionInfo = doc.getRevisionInfo()
+  if (revisionInfo.isEmpty()) {
+    return undefined
+  }
+  return {
+    number: revisionInfo.getNumber() || null,
+    date: revisionInfo.getDate(),
+    remark: revisionInfo.getRemark(),
+  }
+}
+
 export async function convert(url, source) {
   const settings = await getRenderingSettings()
   const options = buildAsciidoctorOptions(settings, url)
   const doc = await load(source, options)
-  if (showTitle(doc)) {
+  const displayHeader = showTitle(doc)
+  if (displayHeader) {
     doc.removeAttribute('notitle')
     doc.setAttribute('showtitle')
   }
@@ -78,6 +108,9 @@ export async function convert(url, source) {
       maxWidth: doc.getAttribute('max-width'),
       eqnumsValue,
       stylesheet: doc.getAttribute('stylesheet'),
+      authors: displayHeader ? getAuthors(doc) : [],
+      revisionInfo: displayHeader ? getRevisionInfo(doc) : undefined,
+      favicon: doc.getAttribute('favicon'),
     },
   }
 }

--- a/app/js/module/page.js
+++ b/app/js/module/page.js
@@ -200,6 +200,107 @@ const updateContent = (html) => {
 }
 
 /**
+ * Update (or remove) the page's favicon from the :favicon: document attribute.
+ * The href is resolved by the browser against the current tab URL, the same
+ * way relative image references in the document already are.
+ * @param favicon The :favicon: attribute value, or a falsy value to remove it
+ */
+const updateFavicon = (favicon) => {
+  const id = 'asciidoctor-browser-favicon'
+  let link = document.getElementById(id)
+  if (!favicon) {
+    if (link) {
+      link.remove()
+    }
+    return
+  }
+  if (!link) {
+    link = document.createElement('link')
+    link.id = id
+    link.rel = 'icon'
+    document.head.appendChild(link)
+  }
+  link.href = favicon
+}
+
+/**
+ * Build the <div class="details"> block (author(s) + revision info), matching
+ * the markup Asciidoctor's standalone <div id="header"> template produces.
+ * The embeddable output used by this extension never includes it, so it has
+ * to be reconstructed here (see asciidoctor/asciidoctor-browser-extension#460).
+ * @param authors
+ * @param revisionInfo
+ * @returns {HTMLDivElement}
+ */
+const createDetailsElement = (authors, revisionInfo) => {
+  const details = document.createElement('div')
+  details.className = 'details'
+  authors.forEach((author, index) => {
+    const suffix = index === 0 ? '' : `${index + 1}`
+    const authorSpan = document.createElement('span')
+    authorSpan.id = `author${suffix}`
+    authorSpan.className = 'author'
+    authorSpan.textContent = author.name
+    details.appendChild(authorSpan)
+    details.appendChild(document.createElement('br'))
+    if (author.email) {
+      const emailSpan = document.createElement('span')
+      emailSpan.id = `email${suffix}`
+      emailSpan.className = 'email'
+      const emailLink = document.createElement('a')
+      emailLink.href = `mailto:${author.email}`
+      emailLink.textContent = author.email
+      emailSpan.appendChild(emailLink)
+      details.appendChild(emailSpan)
+      details.appendChild(document.createElement('br'))
+    }
+  })
+  if (revisionInfo) {
+    if (revisionInfo.number) {
+      const revnumberSpan = document.createElement('span')
+      revnumberSpan.id = 'revnumber'
+      revnumberSpan.textContent = `version ${revisionInfo.number}${revisionInfo.date ? ',' : ''}`
+      details.appendChild(revnumberSpan)
+    }
+    if (revisionInfo.date) {
+      const revdateSpan = document.createElement('span')
+      revdateSpan.id = 'revdate'
+      revdateSpan.textContent = revisionInfo.date
+      details.appendChild(revdateSpan)
+    }
+    if (revisionInfo.remark) {
+      details.appendChild(document.createElement('br'))
+      const revremarkSpan = document.createElement('span')
+      revremarkSpan.id = 'revremark'
+      revremarkSpan.textContent = revisionInfo.remark
+      details.appendChild(revremarkSpan)
+    }
+  }
+  return details
+}
+
+/**
+ * Wrap the document title (rendered by Asciidoctor as a bare <h1> at the root
+ * of #content in embeddable output) together with the author/revision details
+ * block in a <div id="header">, so the existing theme stylesheets — written
+ * against Asciidoctor's standalone #header markup — style it correctly.
+ * @param authors
+ * @param revisionInfo
+ */
+const wrapHeader = (authors, revisionInfo) => {
+  const contentElement = document.getElementById('content')
+  const titleElement = contentElement?.querySelector(':scope > h1:first-child')
+  if (!titleElement) {
+    return
+  }
+  const headerElement = document.createElement('div')
+  headerElement.id = 'header'
+  titleElement.replaceWith(headerElement)
+  headerElement.appendChild(titleElement)
+  headerElement.appendChild(createDetailsElement(authors, revisionInfo))
+}
+
+/**
  * Update the HTML document with the Asciidoctor document
  * @param converterResponse The response sent by the converter
  * @param scripts The scripts to restore
@@ -221,6 +322,10 @@ const updateBodyHTML = async (converterResponse, scripts) => {
     document.body.style.maxWidth = maxWidth
   }
   updateContent(converterResponse.html)
+  updateFavicon(attributes.favicon)
+  if (attributes.authors.length > 0 || attributes.revisionInfo) {
+    wrapHeader(attributes.authors, attributes.revisionInfo)
+  }
   let tocClassNames = ''
   if (
     attributes.hasSections &&

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -15,6 +15,8 @@
 * Add a "Remove" button next to the JavaScript dropdown in the options page, to delete a previously added custom script, and fix the existing theme "Remove" button to also clear the entry from `browser.storage.local` (it was only clearing `localStorage`, leaking the stylesheet content indefinitely)
 * Make the default `asciidoctor` theme dark-mode compatible, matching the reader's OS-level `prefers-color-scheme`: dark syntax highlighting (`atom-one-dark`, when the `github` highlight theme is in use), fix table row striping and admonition icon colors that a specificity conflict in the base theme had left unstyled or too dark, and restyle inline Kroki `<svg>` diagrams (`filter: invert(1) hue-rotate(180deg)`) for documents that opt in with `:kroki-default-options: inline` (requires an `asciidoctor-kroki` version with the browser `toDataUri` fix)
 * Fix removing a custom theme not reliably restoring the default `asciidoctor` theme (even after a refresh): the reset relied on a debounced autosave that could be skipped or lost, so save it immediately instead
+* Render the author(s) and revision info (number, date, remark) in a `#header` block above the table of contents, matching Asciidoctor's standalone output, since the embeddable output the extension uses never included them (#460)
+* Add support for the `:favicon:` document attribute (#688)
 
 == 3.0.0 (2025-05-03)
 

--- a/spec/browser/asciidoctor.spec.js
+++ b/spec/browser/asciidoctor.spec.js
@@ -450,6 +450,99 @@ By default, the title must be shown.
 
     await expect(page.locator('h1')).toHaveText('Hello world')
   })
+
+  test('should render the author and revision info in a #header block', async ({
+    page,
+  }) => {
+    await page.evaluate(async () => {
+      const params = []
+      params[Constants.ENABLE_RENDER_KEY] = 'true'
+      params[Constants.CUSTOM_ATTRIBUTES_KEY] = ''
+      params[Constants.SAFE_MODE_KEY] = 'safe'
+      helper.configureParameters(params)
+
+      const source = `= Hello world
+John Doe <john@example.com>; Jane Roe <jane@example.com>
+v1.2, 2024-01-15: Initial release
+
+Content.
+`
+      const response = await Converter.convert(
+        window.location.toString(),
+        source,
+      )
+      await Renderer.updateHTML(response)
+    })
+
+    await expect(page.locator('#header > h1')).toHaveText('Hello world')
+    await expect(page.locator('#header .details #author')).toHaveText(
+      'John Doe',
+    )
+    await expect(page.locator('#header .details #email a')).toHaveAttribute(
+      'href',
+      'mailto:john@example.com',
+    )
+    await expect(page.locator('#header .details #author2')).toHaveText(
+      'Jane Roe',
+    )
+    await expect(page.locator('#header .details #revnumber')).toHaveText(
+      'version 1.2,',
+    )
+    await expect(page.locator('#header .details #revdate')).toHaveText(
+      '2024-01-15',
+    )
+    await expect(page.locator('#header .details #revremark')).toHaveText(
+      'Initial release',
+    )
+  })
+
+  test('should not wrap the title in a #header block when there is no author or revision info', async ({
+    page,
+  }) => {
+    await page.evaluate(async () => {
+      const params = []
+      params[Constants.ENABLE_RENDER_KEY] = 'true'
+      params[Constants.CUSTOM_ATTRIBUTES_KEY] = ''
+      params[Constants.SAFE_MODE_KEY] = 'safe'
+      helper.configureParameters(params)
+
+      const response = await Converter.convert(
+        window.location.toString(),
+        '= Hello world',
+      )
+      await Renderer.updateHTML(response)
+    })
+
+    await expect(page.locator('#header')).toHaveCount(0)
+    await expect(page.locator('#content > h1')).toHaveText('Hello world')
+  })
+
+  test('should set the favicon from the :favicon: attribute', async ({
+    page,
+  }) => {
+    await page.evaluate(async () => {
+      const params = []
+      params[Constants.ENABLE_RENDER_KEY] = 'true'
+      params[Constants.CUSTOM_ATTRIBUTES_KEY] = ''
+      params[Constants.SAFE_MODE_KEY] = 'safe'
+      helper.configureParameters(params)
+
+      const source = `= Hello world
+:favicon: favicon.png
+
+Content.
+`
+      const response = await Converter.convert(
+        window.location.toString(),
+        source,
+      )
+      await Renderer.updateHTML(response)
+    })
+
+    await expect(
+      page.locator('link#asciidoctor-browser-favicon'),
+    ).toHaveAttribute('href', /favicon\.png$/)
+  })
 })
 
 test.describe('Theme module', () => {


### PR DESCRIPTION
Asciidoctor's embeddable output (used by this extension instead of standalone `header_footer` output — see #217, where that alternative was deliberately rejected in favor of incrementally closing the gap) never includes the author/email/revision `<div class="details">` block or the `:favicon:` attribute, since both are only emitted by the standalone template.

This exposes them from `converter.js` and reconstructs the missing pieces in `page.js`:
- wraps the title in a synthetic `#header` (only when there's an author or revision to show, so documents without either are unaffected) so the existing theme stylesheets — written against Asciidoctor's standalone markup — style it correctly with zero CSS changes
- adds/removes a `<link rel="icon">` from `:favicon:`

Closes #460, closes #688.
