### PR TITLE
fix: space out the synthetic #header from the preamble and drop its doubled padding

### DIFF
--- a/app/js/module/page.js
+++ b/app/js/module/page.js
@@ -295,6 +295,15 @@ const wrapHeader = (authors, revisionInfo) => {
   }
   const headerElement = document.createElement('div')
   headerElement.id = 'header'
+  // In standalone output, this gap comes from the theme's `#content { margin-top: 1.25em }`
+  // rule, since #header and #content are siblings there. Here #header ends up nested inside
+  // #content instead (see comment above), so that rule no longer separates it from what follows.
+  headerElement.style.marginBottom = '1.25em'
+  // Themes style `#header, #content, #footnotes, #footer` as one combined selector, including
+  // left/right padding, meant for siblings each carrying their own. Nested inside #content,
+  // #header would otherwise get that padding a second time and sit indented past the body text.
+  headerElement.style.paddingLeft = '0'
+  headerElement.style.paddingRight = '0'
   titleElement.replaceWith(headerElement)
   headerElement.appendChild(titleElement)
   headerElement.appendChild(createDetailsElement(authors, revisionInfo))

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -15,7 +15,7 @@
 * Add a "Remove" button next to the JavaScript dropdown in the options page, to delete a previously added custom script, and fix the existing theme "Remove" button to also clear the entry from `browser.storage.local` (it was only clearing `localStorage`, leaking the stylesheet content indefinitely)
 * Make the default `asciidoctor` theme dark-mode compatible, matching the reader's OS-level `prefers-color-scheme`: dark syntax highlighting (`atom-one-dark`, when the `github` highlight theme is in use), fix table row striping and admonition icon colors that a specificity conflict in the base theme had left unstyled or too dark, and restyle inline Kroki `<svg>` diagrams (`filter: invert(1) hue-rotate(180deg)`) for documents that opt in with `:kroki-default-options: inline` (requires an `asciidoctor-kroki` version with the browser `toDataUri` fix)
 * Fix removing a custom theme not reliably restoring the default `asciidoctor` theme (even after a refresh): the reset relied on a debounced autosave that could be skipped or lost, so save it immediately instead
-* Render the author(s) and revision info (number, date, remark) in a `#header` block above the table of contents, matching Asciidoctor's standalone output, since the embeddable output the extension uses never included them (#460)
+* Render the author(s) and revision info (number, date, remark) in a `#header` block above the table of contents, matching Asciidoctor's standalone output, since the embeddable output the extension uses never included them, with a small margin below it so the preamble isn't flush against the title/details (#460)
 * Add support for the `:favicon:` document attribute (#688)
 
 == 3.0.0 (2025-05-03)


### PR DESCRIPTION
Themes style `#header, #content, #footnotes, #footer` as one combined selector, sized for siblings: `#content's top margin creates the gap below the header, and each element carries its own left/right padding. Since the header is reconstructed as a child of `#content` in embeddable output (470df5f), it inherited neither benefit — the preamble sat flush against the title/details, and the title was indented twice.