### PR TITLE
fix: skip auto-reload DOM update when fetched content is unchanged

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -68,16 +68,45 @@ function displayContentAsPlainText(text) {
   document.body.appendChild(preElement)
 }
 
+// Last content actually rendered, so a poll tick that returns the same
+// content can skip the DOM update. Rebuilding the DOM on every tick (even
+// when nothing changed) resets the page, which drops any text selection the
+// user was in the middle of making (particularly painful for the plain-text
+// rendering, where selecting/copying the raw source is the whole point).
+let lastRenderedContent
+
+function isSameAsLastRendered(response) {
+  if (response.html) {
+    return (
+      lastRenderedContent?.type === 'html' &&
+      lastRenderedContent.value === response.html
+    )
+  }
+  if (response.text) {
+    return (
+      lastRenderedContent?.type === 'text' &&
+      lastRenderedContent.value === response.text
+    )
+  }
+  return false
+}
+
+async function applyResponse(response) {
+  if (response.html) {
+    lastRenderedContent = { type: 'html', value: response.html }
+    await updateHTML(response)
+  } else if (response.text) {
+    lastRenderedContent = { type: 'text', value: response.text }
+    displayContentAsPlainText(response.text)
+  } else if (response.error) {
+    showError(response.error)
+  }
+}
+
 async function showResponse(response) {
   if (response) {
     setViewport()
-    if (response.html) {
-      await updateHTML(response)
-    } else if (response.text) {
-      displayContentAsPlainText(response.text)
-    } else if (response.error) {
-      showError(response.error)
-    }
+    await applyResponse(response)
   }
   revealPage()
 }
@@ -112,15 +141,9 @@ async function startAutoReload() {
     try {
       webExtension.runtime.sendMessage(
         { action: 'fetch-convert' },
-        (response) => {
-          if (response) {
-            if (response.html) {
-              updateHTML(response)
-            } else if (response.text) {
-              displayContentAsPlainText(response.text)
-            } else if (response.error) {
-              showError(response.error)
-            }
+        async (response) => {
+          if (response && !isSameAsLastRendered(response)) {
+            await applyResponse(response)
           }
         },
       )

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -19,6 +19,7 @@
 * Add support for the `:favicon:` document attribute (#688)
 * Fix the "Render selection" context menu action, which was broken: `inject.html` referenced JavaScript files that no longer exist (`namespace.js`, `converter.js`, `renderer.js`, leftovers from before the switch to ES modules) and loaded `inject.js` as a classic script even though it uses `import`
 * Merge `module/fetch.js` into `module/converter.js`, its only caller
+* Fix auto-reload rebuilding the whole page on every poll tick even when the fetched content hadn't changed, which reset the page and dropped any in-progress text selection (most noticeable in the plain-text rendering, where selecting/copying the source is the whole point); skip the DOM update when the content is unchanged
 
 == 3.0.0 (2025-05-03)
 


### PR DESCRIPTION
Every auto-reload poll tick rebuilt the whole page (via `updateHTML`/`displayContentAsPlainText`) even when the fetched content was byte-for-byte identical to what was already rendered. This reset the page on a timer, dropping any in-progress text selection — especially noticeable in the plain-text rendering, where selecting/copying the source is the whole point.

The content actually rendered is now tracked, and the poll tick skips the DOM update when the newly fetched HTML/text matches it, leaving the current selection intact.