### PR TITLE
Let a custom theme override a built-in theme of the same name

### DIFF
--- a/app/js/module/page.js
+++ b/app/js/module/page.js
@@ -193,8 +193,17 @@ const appendCustomScript = (content) => {
 }
 
 async function appendThemeStyle(themeName) {
+  // A custom theme takes precedence over a built-in one of the same name
+  // (e.g. a user-uploaded "asciidoctor.css"), rather than being silently
+  // shadowed by it.
+  const customThemeContent = await getSetting(
+    Constants.CUSTOM_THEME_PREFIX + themeName,
+  )
+  if (customThemeContent) {
+    insertInlineCss(`custom-theme-${themeName}`, customThemeContent)
+    return
+  }
   const themeNames = getDefaultThemeNames()
-  // Check if the theme is packaged in the extension... if not it's a custom theme
   if (themeNames.includes(themeName)) {
     const file = `css/themes/${themeName}.css`
     if (currentThemeCssFile !== file) {
@@ -213,13 +222,6 @@ async function appendThemeStyle(themeName) {
       }
       currentThemeCssFile = file
       webExtension.runtime.sendMessage({ action: 'insert-css', file })
-    }
-  } else {
-    const customThemeContent = await getSetting(
-      Constants.CUSTOM_THEME_PREFIX + themeName,
-    )
-    if (customThemeContent) {
-      insertInlineCss(`custom-theme-${themeName}`, customThemeContent)
     }
   }
 }

--- a/app/js/module/theme.js
+++ b/app/js/module/theme.js
@@ -50,14 +50,16 @@ export function getDefaultThemeNames() {
  * @returns {Promise<boolean>}
  */
 async function hasTheme(themeName) {
-  const themeNames = getDefaultThemeNames()
-  if (themeNames.includes(themeName)) {
-    return true
-  }
+  // A custom theme takes precedence over a built-in one of the same name,
+  // matching appendThemeStyle() in page.js.
   const customThemeContent = await getSetting(
     Constants.CUSTOM_THEME_PREFIX + themeName,
   )
-  return !!customThemeContent
+  if (customThemeContent) {
+    return true
+  }
+  const themeNames = getDefaultThemeNames()
+  return themeNames.includes(themeName)
 }
 
 /**

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -20,6 +20,7 @@
 * Fix the "Render selection" context menu action, which was broken in several ways: `inject.html` referenced JavaScript files that no longer exist (`namespace.js`, `converter.js`, `renderer.js`, leftovers from before the switch to ES modules) and loaded `inject.js` as a classic script even though it uses `import`; the context menu handler used `tabs.executeScript` and `extension.getViews`, both removed in Manifest V3; and applying the theme CSS failed too because `chrome.scripting` can't target the extension's own pages -- CSS is now applied directly to the document in that case, and a configured custom JavaScript is skipped there since there's no CSP-compliant way to run it on an extension page (#113)
 * Merge `module/fetch.js` into `module/converter.js`, its only caller
 * Fix auto-reload rebuilding the whole page on every poll tick even when the fetched content hadn't changed, which reset the page and dropped any in-progress text selection (most noticeable in the plain-text rendering, where selecting/copying the source is the whole point); skip the DOM update when the content is unchanged
+* Fix a custom theme being silently shadowed by a built-in theme of the same name (e.g. a user-uploaded `asciidoctor.css`): a custom theme now takes precedence over a built-in one when both share a name (#304)
 
 == 3.0.0 (2025-05-03)
 

--- a/spec/browser/asciidoctor.spec.js
+++ b/spec/browser/asciidoctor.spec.js
@@ -404,6 +404,44 @@ test.describe('Update the HTML document', () => {
     await expect(page.locator('#content')).toContainText('Hello world')
   })
 
+  test('should prefer a custom theme over a built-in theme of the same name', async ({
+    page,
+  }) => {
+    const insertCssMessages = await page.evaluate(async () => {
+      const params = []
+      params[Constants.ENABLE_RENDER_KEY] = 'true'
+      params[Constants.CUSTOM_ATTRIBUTES_KEY] = ''
+      params[Constants.SAFE_MODE_KEY] = 'safe'
+      params[`${Constants.CUSTOM_THEME_PREFIX}asciidoctor`] =
+        'h1 { color: red; }'
+      helper.configureParameters(params)
+      helper.configureManifest({
+        web_accessible_resources: [
+          { resources: ['css/themes/asciidoctor.css'] },
+        ],
+      })
+
+      const spy = sinon.spy(browser.runtime, 'sendMessage')
+      const response = await Converter.convert(
+        window.location.toString(),
+        '= Hello world',
+      )
+      await Renderer.updateHTML(response)
+      return spy
+        .getCalls()
+        .map((call) => call.args[0])
+        .filter((message) => message.action === 'insert-css')
+    })
+    expect(
+      insertCssMessages.some((message) => message.css === 'h1 { color: red; }'),
+    ).toBe(true)
+    expect(
+      insertCssMessages.some(
+        (message) => message.file === 'css/themes/asciidoctor.css',
+      ),
+    ).toBe(false)
+  })
+
   test('should hide the document title when noheader attribute is defined', async ({
     page,
   }) => {


### PR DESCRIPTION
`appendThemeStyle()` (`app/js/module/page.js`) and `hasTheme()` (`app/js/module/theme.js`) both checked the built-in theme list before looking for a matching custom theme, so uploading a custom theme with the same name as a built-in one (e.g. a custom `asciidoctor.css`) silently had no effect -- the built-in stylesheet always won, with no error or indication of why.

Swapped the check order so a custom theme takes precedence over a built-in one of the same name, matching one of the options discussed in the issue. Added a test asserting the custom stylesheet content is what gets inserted, not the built-in file.

Closes #304.
