### PR TITLE
Stop polling for changes while the tab is hidden

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -139,6 +139,11 @@ async function startAutoReload() {
   }
   autoReloadInterval = setInterval(async () => {
     try {
+      // Skip the fetch entirely while the tab isn't visible, so a background
+      // tab doesn't keep polling on every tick (see #232).
+      if (document.hidden) {
+        return
+      }
       webExtension.runtime.sendMessage(
         { action: 'fetch-convert' },
         async (response) => {

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -21,6 +21,7 @@
 * Merge `module/fetch.js` into `module/converter.js`, its only caller
 * Fix auto-reload rebuilding the whole page on every poll tick even when the fetched content hadn't changed, which reset the page and dropped any in-progress text selection (most noticeable in the plain-text rendering, where selecting/copying the source is the whole point); skip the DOM update when the content is unchanged
 * Fix a custom theme being silently shadowed by a built-in theme of the same name (e.g. a user-uploaded `asciidoctor.css`): a custom theme now takes precedence over a built-in one when both share a name (#304)
+* Stop polling for changes while the tab is hidden, so a backgrounded tab doesn't keep fetching and converting the document on every tick (#232)
 
 == 3.0.0 (2025-05-03)
 

--- a/spec/browser/asciidoctor.spec.js
+++ b/spec/browser/asciidoctor.spec.js
@@ -753,6 +753,51 @@ test.describe('Extension initialization', () => {
     expect(result.initial).toBe(true)
   })
 
+  test('should stop polling for changes while the tab is hidden', async ({
+    page,
+  }) => {
+    const result = await page.evaluate(async () => {
+      const params = []
+      params[Constants.ENABLE_RENDER_KEY] = true
+      helper.configureParameters(params)
+
+      const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+      const clock = sinon.useFakeTimers({
+        toFake: ['setInterval', 'clearInterval'],
+      })
+      try {
+        await Loader.init()
+        await flush()
+
+        const spy = sinon.spy(browser.runtime, 'sendMessage')
+
+        Object.defineProperty(document, 'hidden', {
+          configurable: true,
+          get: () => true,
+        })
+        await clock.tickAsync(2100)
+        await flush()
+        const calledWhileHidden = spy.called
+
+        spy.resetHistory()
+        Object.defineProperty(document, 'hidden', {
+          configurable: true,
+          get: () => false,
+        })
+        await clock.tickAsync(2100)
+        await flush()
+        const calledWhileVisible = spy.called
+
+        return { calledWhileHidden, calledWhileVisible }
+      } finally {
+        clock.restore()
+        delete document.hidden
+      }
+    })
+    expect(result.calledWhileHidden).toBe(false)
+    expect(result.calledWhileVisible).toBe(true)
+  })
+
   test('should not fetch the content from the background script if the extension is disabled', async ({
     page,
   }) => {


### PR DESCRIPTION
The auto-reload `setInterval` in `app/js/main.js` kept fetching and converting the document on every tick regardless of tab visibility, wasting CPU/network on backgrounded tabs -- and per the linked issue, potentially contributing to browser crashes when many such tabs are left open.

Skip the tick entirely while `document.hidden` is true, resuming normal polling once the tab becomes visible again. Added a test using fake timers to assert no `sendMessage` call happens on a tick while hidden, and that polling resumes once visible.

Closes #232.
