### PR TITLE
ci: cache playwright browsers to speed up windows runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,22 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: |
           npx playwright install --with-deps chromium
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true' && matrix.os == 'ubuntu-latest'
+        run: |
+          npx playwright install-deps chromium
       - name: Lint, build and test
         shell: bash
         run: |


### PR DESCRIPTION
Downloading chromium via playwright install --with-deps takes ~3min on windows-latest for every run. Cache the browser binaries keyed on package-lock.json so unchanged runs skip the download.