### PR TITLE
Open the quickstart guide on first install

### DIFF
--- a/app/js/background.js
+++ b/app/js/background.js
@@ -181,7 +181,12 @@ const renderSelectionMenuItemId = 'renderSelectionMenuItem'
 // for, keyed by that tab's id (see the 'get-selection' message below).
 const pendingSelections = new Map()
 
-webExtension.runtime.onInstalled.addListener(() => {
+webExtension.runtime.onInstalled.addListener((details) => {
+  if (details.reason === 'install') {
+    webExtension.tabs.create({
+      url: 'https://docs.asciidoctor.org/browser-extension/quickstart/',
+    })
+  }
   if (webExtension.contextMenus) {
     webExtension.contextMenus.create({
       id: renderSelectionMenuItemId,

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -26,6 +26,7 @@
 * Add a keyboard shortcut (`Alt+Shift+R` by default, configurable at `browser://extensions/shortcuts`) to toggle between the rendered and raw view (#186)
 * *Behavior change*: only `.adoc` and `.asciidoc` files are rendered by default now; `.ad` and `.asc` join `.txt` as opt-in extensions, each with their own checkbox on the options page (#677)
 * Fix the bottom padding being too tight when a document has footnotes: the base stylesheet zeroes it out to avoid double-spacing before `#footer`, but the extension's embeddable output never renders a `#footer` (#120)
+* Open the quickstart guide in a new tab the first time the extension is installed (#528)
 
 == 3.0.0 (2025-05-03)
 


### PR DESCRIPTION
`runtime.onInstalled` only wired up the "Render selection" context menu; there was no onboarding of any kind for a first-time install, so a new user gets a toolbar icon with no indication of how to enable the extension on local files or what it can do.

Check `details.reason === 'install'` and open the quickstart documentation page (https://docs.asciidoctor.org/browser-extension/quickstart/) in a new tab in that case only -- not on extension/browser updates.

Closes #528.
