### PR TITLE
Add a keyboard shortcut to toggle the rendered/raw view

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -378,6 +378,14 @@
   "action": {
     "default_title": "Asciidoctor.js Preview"
   },
+  "commands": {
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Alt+Shift+R"
+      },
+      "description": "Toggle between the rendered and raw view"
+    }
+  },
   "background": {
     "service_worker": "js/background.js",
     "type": "module"

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -22,6 +22,7 @@
 * Fix auto-reload rebuilding the whole page on every poll tick even when the fetched content hadn't changed, which reset the page and dropped any in-progress text selection (most noticeable in the plain-text rendering, where selecting/copying the source is the whole point); skip the DOM update when the content is unchanged
 * Fix a custom theme being silently shadowed by a built-in theme of the same name (e.g. a user-uploaded `asciidoctor.css`): a custom theme now takes precedence over a built-in one when both share a name (#304)
 * Stop polling for changes while the tab is hidden, so a backgrounded tab doesn't keep fetching and converting the document on every tick (#232)
+* Add a keyboard shortcut (`Alt+Shift+R` by default, configurable at `browser://extensions/shortcuts`) to toggle between the rendered and raw view (#186)
 
 == 3.0.0 (2025-05-03)
 


### PR DESCRIPTION
Wired up the manifest's special `_execute_action` command, which Chrome/Firefox fire as if the toolbar icon itself was clicked -- so it reuses the existing `action.onClicked` listener (`enableDisableRender()`) with no background script changes needed.

Default shortcut is `Alt+Shift+R`, remappable per-user at `browser://extensions/shortcuts`. Useful for keyboard-only setups (the original request was from a Vimperator user with no visible toolbar).

Closes #186.
