### PR TITLE
Use a union merge for changelog.adoc

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+changelog.adoc merge=union

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -7,6 +7,7 @@
 * Replace ESLint and Standard with Biome for linting and formatting
 * Replace Puppeteer and Mocha/Chai with Playwright for browser tests
 * Rename `lint:firefox` npm script to `validate:firefox`
+* Mark `changelog.adoc` with a `merge=union` git attribute, so parallel branches that each append an entry to the "Unreleased" section merge automatically instead of conflicting
 * Remove Bulma and Sass, replace the generated options page stylesheet with a small hand-written CSS file
 * Restructure `contrib/samples` into a single coherent multi-chapter sample book instead of a set of disconnected syntax snippets
 * Modernize `navigation.js`, add new `restore-scroll-position.js` and `toc-scrollspy.js` examples, and move all three from `contrib` into the Antora documentation as downloadable examples of the JavaScript "before"/"after" load hooks


### PR DESCRIPTION
Several recent parallel PRs each append one line to the "Unreleased" section, right before the next version heading -- which conflicts on essentially every rebase/merge even though the intended resolution is always "keep both lines".

Mark `changelog.adoc` with `merge=union` in `.gitattributes` so git resolves these automatically instead of stopping for manual conflict resolution.
