### PR TITLE
Restore bottom padding after footnotes in the embeddable output

### DIFF
--- a/app/css/themes/asciidoctor.css
+++ b/app/css/themes/asciidoctor.css
@@ -473,3 +473,19 @@ blockquote,blockquote p,.quoteblock blockquote,.quoteblock p{color:rgba(255,255,
 .sidebarblock>.content>.title{color:#e2775f}
 .subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{color:#e2775f}
 }
+
+/* Overrides for the default asciidoctor theme needed because the extension
+ * renders Asciidoctor's embeddable output (header_footer: false), which
+ * never includes a #footer. Appended to app/css/themes/asciidoctor.css
+ * during the build, after that file is copied fresh from
+ * @asciidoctor/core on every build. */
+
+/* The base stylesheet sets #content #footnotes's padding-bottom to .75em
+ * (via the "padding: .75em 0" shorthand) to avoid double-spacing before
+ * #footer. Without a #footer, that leaves the page ending too close to the
+ * last footnote (asciidoctor-browser-extension#120). Matching the base
+ * rule's #content #footnotes specificity (rather than just #footnotes) so
+ * this reliably wins the cascade regardless of source order. */
+#content #footnotes:last-child {
+  padding-bottom: 1.25em;
+}

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -25,6 +25,7 @@
 * Stop polling for changes while the tab is hidden, so a backgrounded tab doesn't keep fetching and converting the document on every tick (#232)
 * Add a keyboard shortcut (`Alt+Shift+R` by default, configurable at `browser://extensions/shortcuts`) to toggle between the rendered and raw view (#186)
 * *Behavior change*: only `.adoc` and `.asciidoc` files are rendered by default now; `.ad` and `.asc` join `.txt` as opt-in extensions, each with their own checkbox on the options page (#677)
+* Fix the bottom padding being too tight when a document has footnotes: the base stylesheet zeroes it out to avoid double-spacing before `#footer`, but the extension's embeddable output never renders a `#footer` (#120)
 
 == 3.0.0 (2025-05-03)
 

--- a/src/css/asciidoctor-embeddable-overrides.css
+++ b/src/css/asciidoctor-embeddable-overrides.css
@@ -1,0 +1,15 @@
+/* Overrides for the default asciidoctor theme needed because the extension
+ * renders Asciidoctor's embeddable output (header_footer: false), which
+ * never includes a #footer. Appended to app/css/themes/asciidoctor.css
+ * during the build, after that file is copied fresh from
+ * @asciidoctor/core on every build. */
+
+/* The base stylesheet sets #content #footnotes's padding-bottom to .75em
+ * (via the "padding: .75em 0" shorthand) to avoid double-spacing before
+ * #footer. Without a #footer, that leaves the page ending too close to the
+ * last footnote (asciidoctor-browser-extension#120). Matching the base
+ * rule's #content #footnotes specificity (rather than just #footnotes) so
+ * this reliably wins the cascade regardless of source order. */
+#content #footnotes:last-child {
+  padding-bottom: 1.25em;
+}

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -66,6 +66,16 @@ function appendDarkModeStyles() {
   fs.appendFileSync(path, `\n${darkModeCss}`)
 }
 
+function appendEmbeddableOverrides() {
+  const path = 'app/css/themes/asciidoctor.css'
+  console.log('Append embeddable-output overrides to asciidoctor.css')
+  const embeddableCss = fs.readFileSync(
+    'src/css/asciidoctor-embeddable-overrides.css',
+    'utf8',
+  )
+  fs.appendFileSync(path, `\n${embeddableCss}`)
+}
+
 function replaceImagesURL() {
   for (const themeName of ['github', 'golo', 'maker', 'riak']) {
     const path = `app/css/themes/${themeName}.css`
@@ -234,6 +244,7 @@ await bundleChartist()
 await downloadFonts()
 replaceFontsImport()
 appendDarkModeStyles()
+appendEmbeddableOverrides()
 replaceImagesURL()
 minifyOptionsCss()
 await bundleContentScript()


### PR DESCRIPTION
The base asciidoctor stylesheet sets `#content #footnotes`'s `padding-bottom` to `.75em` specifically to avoid double-spacing before `#footer`. The extension renders Asciidoctor's embeddable output (`header_footer: false`), which never includes a `#footer`, so documents with footnotes end with barely any bottom margin -- reported with screenshots in the issue.

Added `#content #footnotes:last-child { padding-bottom: 1.25em }` as a new build-time override (`src/css/asciidoctor-embeddable-overrides.css`, appended to `app/css/themes/asciidoctor.css` at build time alongside the existing dark-mode overrides). Matches the base rule's specificity so it reliably wins the cascade, and is gated on `:last-child` so it backs off automatically if something (a real `#footer`) follows the footnotes.

Verified against a real browser rendering (computed `padding-bottom` goes from 12px to 20px, and stays 12px when a trailing element follows) since theme CSS is applied via the background script's `scripting.insertCSS` and isn't visible from the existing Playwright test harness.

Fix suggested by @mojavelinux (Asciidoctor maintainer) directly in the issue thread.

Closes #120.
